### PR TITLE
feat: 접근 권한 제어 커스텀 훅 및 로그인/비로그인 상태 처리 기능 추가

### DIFF
--- a/Client/src/api/userApi.ts
+++ b/Client/src/api/userApi.ts
@@ -51,7 +51,8 @@ export const requestGuestUser = async () => {
 
 export const requestLogOut = async () => {
   try {
-    localStorage.clear()
+    localStorage.removeItem('token')
+    localStorage.removeItem('account-storage')
     sessionStorage.clear()
     console.log('✅ 로그아웃 성공')
   } catch (error) {

--- a/Client/src/hook/useAuthRedirect.ts
+++ b/Client/src/hook/useAuthRedirect.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+// 로그인 or 게스트 유저만 접근 가능 (비 로그인 x)
+export const useRequireUserOrGuest = (redirectUrl: string = '/') => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const isLogin = !!localStorage.getItem('token')
+    const isGuest = !!sessionStorage.getItem('guest-storage')
+
+    if (!isLogin && !isGuest) {
+      navigate(redirectUrl)
+    }
+  }, [navigate, redirectUrl])
+}
+
+// 로그인 유저만 접근 가능 (게스트, 비 로그인 x)
+export const useRequireUser = (redirectUrl: string = '/') => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const isLogin = !!localStorage.getItem('token')
+    const isGuest = !!sessionStorage.getItem('guest-storage')
+
+    if (isGuest || !isLogin) {
+      navigate(redirectUrl)
+    }
+  }, [navigate, redirectUrl])
+}
+
+// 비 로그인 유저만 접근 가능 (로그인, 게스트 x)
+export const useRequireNoAuth = (redirectUrl: string = '/') => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const isLogin = !!localStorage.getItem('token')
+    const isGuest = !!sessionStorage.getItem('guest-storage')
+
+    if (isLogin || isGuest) {
+      navigate(redirectUrl)
+    }
+  }, [navigate, redirectUrl])
+}

--- a/Client/src/layouts/Header.tsx
+++ b/Client/src/layouts/Header.tsx
@@ -9,6 +9,8 @@ const Header = () => {
   // darkMode: 다크모드 활성화 여부
   // toggleDarkMode: 다크모드를 온오프 함수
   const { darkMode, toggleDarkMode } = useThemeStore()
+  const isLogin = !!localStorage.getItem('token')
+  const isGuest = !!sessionStorage.getItem('guest-storage')
 
   const navLinks = [
     { to: '/charts', label: '시세차트' },
@@ -107,14 +109,24 @@ const Header = () => {
                 ))}
                 {/* 사이드바 프로필 이동 링크*/}
                 <Link
-                  to='/account'
+                  to='/userinfo'
                   className='flex h-full items-center border-b border-white/30 whitespace-nowrap'
                 >
                   <h3 className='pl-2 text-white'>프로필</h3>
                 </Link>
-                <button className='m-0 border-none bg-transparent p-0' onClick={handleLogout}>
-                  <h3 className='pl-2 text-white'>로그아웃</h3>
-                </button>
+                {/* 로그인 / 로그아웃 버튼 */}
+                {isLogin == true || isGuest == true ? (
+                  <button className='m-0 border-none bg-transparent p-0' onClick={handleLogout}>
+                    <h3 className='pl-2 text-white'>로그아웃</h3>
+                  </button>
+                ) : (
+                  <Link
+                    to='/login'
+                    className='flex h-full items-center border-b border-white/30 whitespace-nowrap'
+                  >
+                    <h3 className='pl-2 text-white'>로그인</h3>
+                  </Link>
+                )}
 
                 <div className='mt-7 flex items-center justify-center space-x-5 rounded-3xl border py-1.5'>
                   <label className=''>

--- a/Client/src/pages/Login.tsx
+++ b/Client/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { AuthFormData } from '../types/authTypes'
 import useAccountStore from '../stores/AccountStore'
 import { requestLoginUser } from '../api/userApi'
 import LoginForm from '../components/form/LoginForm'
+import { useRequireNoAuth } from '../hook/useAuthRedirect'
 
 const login = () => {
   const [isLoading, setIsLoading] = useState(false)
@@ -16,6 +17,9 @@ const login = () => {
   const setPassword = useAccountStore((state) => state.setPassword)
   const setApiKey = useAccountStore((state) => state.setApiKey)
   const setCharacter = useAccountStore((state) => state.setCharacter)
+
+  // 비로그인시만 접근가능 (로그인, 게스트시 메인페이지 리다이렉트)
+  useRequireNoAuth()
 
   const handleLoginSubmit = async (data: AuthFormData) => {
     setIsLoading(true)

--- a/Client/src/pages/Register.tsx
+++ b/Client/src/pages/Register.tsx
@@ -6,6 +6,7 @@ import RegisterForm from '../components/form/RegisterForm'
 import useAccountStore from '../stores/AccountStore'
 import { requestRegisterUser } from '../api/userApi'
 import { AuthFormData } from '../types/authTypes'
+import { useRequireNoAuth } from '../hook/useAuthRedirect'
 
 const Register = () => {
   const [isLoading, setIsLoading] = useState(false)
@@ -17,6 +18,9 @@ const Register = () => {
   const setConfirmPassword = useAccountStore((state) => state.setConfirmPassword)
   const setApiKey = useAccountStore((state) => state.setApiKey)
   const setCharacter = useAccountStore((state) => state.setCharacter)
+
+  // 비로그인시 접근가능 (로그인, 게스트 접근 x)
+  useRequireNoAuth()
 
   /**
    * 회원가입 폼 제출 핸들러

--- a/Client/src/pages/Userinfo.tsx
+++ b/Client/src/pages/Userinfo.tsx
@@ -5,6 +5,7 @@ import { AuthFormData } from '../types/authTypes'
 import useAccountStore from '../stores/AccountStore'
 import { requestProfileUpdate } from '../api/userApi'
 import UserinfoForm from '../components/form/UserinfoForm'
+import { useRequireUser } from '../hook/useAuthRedirect'
 
 const Userinfo = () => {
   const [isLoading, setIsLoading] = useState(false)
@@ -12,6 +13,9 @@ const Userinfo = () => {
 
   const setApiKey = useAccountStore((state) => state.setApiKey)
   const setCharacter = useAccountStore((state) => state.setCharacter)
+
+  // 로그인시 접근가능 (게스트, 비로그인 접근 x)
+  useRequireUser('/login')
 
   const handleProfileSubmit = async (data: AuthFormData) => {
     setIsLoading(true)

--- a/Client/src/stores/AccountStore.ts
+++ b/Client/src/stores/AccountStore.ts
@@ -7,6 +7,7 @@ interface accountStoreState {
   confirmPassword: string
   apiKey: string
   character: string
+  isLogin: boolean
   setEmail: (email: string) => void
   setPassword: (password: string) => void
   setConfirmPassword: (confirmPassword: string) => void
@@ -22,7 +23,8 @@ const useAccountStore = create<accountStoreState>()(
       confirmPassword: '',
       apiKey: '',
       character: '',
-      setEmail: (email) => set({ email }),
+      isLogin: false,
+      setEmail: (email) => set({ email, isLogin: email !== '' }),
       setPassword: (password) => set({ password }),
       setConfirmPassword: (confirmPassword) => set({ confirmPassword }),
       setApiKey: (apiKey) => set({ apiKey }),
@@ -34,6 +36,7 @@ const useAccountStore = create<accountStoreState>()(
         email: state.email,
         apiKey: state.apiKey,
         character: state.character,
+        isLogin: state.isLogin,
       }), // 패스워드는 localStorage에 저장하지 않도록 설정
     },
   ),

--- a/Client/src/stores/AccountStore.ts
+++ b/Client/src/stores/AccountStore.ts
@@ -7,7 +7,6 @@ interface accountStoreState {
   confirmPassword: string
   apiKey: string
   character: string
-  isLogin: boolean
   setEmail: (email: string) => void
   setPassword: (password: string) => void
   setConfirmPassword: (confirmPassword: string) => void
@@ -23,8 +22,7 @@ const useAccountStore = create<accountStoreState>()(
       confirmPassword: '',
       apiKey: '',
       character: '',
-      isLogin: false,
-      setEmail: (email) => set({ email, isLogin: email !== '' }),
+      setEmail: (email) => set({ email }),
       setPassword: (password) => set({ password }),
       setConfirmPassword: (confirmPassword) => set({ confirmPassword }),
       setApiKey: (apiKey) => set({ apiKey }),
@@ -36,7 +34,6 @@ const useAccountStore = create<accountStoreState>()(
         email: state.email,
         apiKey: state.apiKey,
         character: state.character,
-        isLogin: state.isLogin,
       }), // 패스워드는 localStorage에 저장하지 않도록 설정
     },
   ),

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -10,35 +10,21 @@ const PORT = process.env.PORT || 5000
 app.use(cors())
 app.use(express.json())
 
-// API 라우터
-const registerRouter = require('./routes/register.js')
-app.use('/api/users/register', registerRouter)
+// 사용자 관련 라우터
+const usersRouter = express.Router()
+usersRouter.use('/register', require('./routes/register'))
+usersRouter.use('/login', require('./routes/login'))
+usersRouter.use('/userinfo', require('./routes/userinfo'))
+app.use('/api/users', usersRouter)
 
-const loginRouter = require('./routes/login.js')
-app.use('/api/users/login', loginRouter)
+// 정적 파일
+const clientDistPath = path.join(__dirname, '../../Client/dist')
+app.use(express.static(clientDistPath))
 
-const userinfoRouter = require('./routes/userinfo.js')
-app.use('/api/users/userinfo', userinfoRouter)
-
-// 메인 페이지(루트 경로)
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../Client/dist/index.html'))
+// 프론트엔드 진입점
+app.get(/^\/(register|login|userinfo)?$/, (req, res) => {
+  res.sendFile(path.join(clientDistPath, 'index.html'))
 })
-
-app.get('/register', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../Client/dist/index.html'))
-})
-
-app.get('/login', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../Client/dist/index.html'))
-})
-
-app.get('/userinfo', (req, res) => {
-  res.sendFile(path.join(__dirname, '../../Client/dist/index.html'))
-})
-
-// 정적 파일 서빙
-app.use(express.static(path.join(__dirname, '../../Client/dist')))
 
 // 서버 실행
 const server = app.listen(PORT, () => {


### PR DESCRIPTION
## ✨ 기능 추가
- 사이드바에 로그인 / 비로그인 상태에 따른 버튼 동작 구현 (로컬)
- 접근 권한 관련 `useAuthAccess` 커스텀 훅 구현  (로그인/게스트/비로그인)

---

## 🎨 프론트엔드 개선
- App 라우터 설정 코드 리팩토링 → 간소화 및 가독성 향상
- 로그아웃 시 localStorage 초기화 로직 추가  
  → `token`, `account-storage` 항목만 삭제 처리

---

## 🧪 테스트 및 확인 내역
- 로그인 상태에서만 접근 가능한 페이지 접근 여부 테스트
- 로그아웃 시 로그인 관련 정보(localStorage) 정상 삭제 확인
- 사이드바의 로그인/로그아웃 버튼 조건부 렌더링 및 작동 확인
