### PR TITLE
feat: mobile 레이아웃 적용

### DIFF
--- a/Client/src/components/Summary/SummaryPreview.tsx
+++ b/Client/src/components/Summary/SummaryPreview.tsx
@@ -5,7 +5,7 @@ import Button from '../ui/Button'
 import { useNavigate } from 'react-router-dom'
 import LevelRangeList from '../barracks/LevelRangeList'
 import { getGoldByLevelRange } from '../../utils/expeditionDataUtils'
-import GoldDashboard from '../goldDashboard'
+import GoldDashboard from '../GoldDashboard'
 
 const SummaryPreview = ({ viewport = '' }) => {
   const expeditionGoldData = getGoldByLevelRange(useExpeditionGoldData() || [])

--- a/Client/src/components/barracks/BarrackList.tsx
+++ b/Client/src/components/barracks/BarrackList.tsx
@@ -9,7 +9,7 @@ const BarrackList = () => {
   const darkMode = useThemeStore((state) => state.darkMode)
 
   return (
-    <div className='w-[430px]'>
+    <div className='w-[90%]'>
       {expeditionLoading && (!expeditions || expeditions.length === 0) ? (
         <div className='flex justify-center'>
           <Loading />

--- a/Client/src/components/charts/PieChart.tsx
+++ b/Client/src/components/charts/PieChart.tsx
@@ -25,6 +25,7 @@ interface PieChartComponentProps {
   outerRadius?: number
   dataKey?: string
   labelLine?: boolean
+  animationDuration?: number
 }
 
 const PieChartComponent: React.FC<PieChartComponentProps> = ({
@@ -34,6 +35,7 @@ const PieChartComponent: React.FC<PieChartComponentProps> = ({
   height = 200,
   outerRadius = 90,
   dataKey = 'totalGold',
+  animationDuration = 600,
 }) => {
   return (
     <PieChart width={width} height={height}>
@@ -46,6 +48,7 @@ const PieChartComponent: React.FC<PieChartComponentProps> = ({
         outerRadius={outerRadius - 5}
         fill='#8884d8'
         dataKey={dataKey}
+        animationDuration={animationDuration}
       >
         {data.map((_entry, index) => (
           <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />

--- a/Client/src/hook/useViewportType.ts
+++ b/Client/src/hook/useViewportType.ts
@@ -4,7 +4,7 @@ type ViewportType = 'mobile' | 'tablet' | 'desktop'
 
 const MOBILE_MAX = 767
 const TABLET_MAX = 1023
-const THROTTLE_DELAY = 200 // ms (원하면 조정 가능)
+const THROTTLE_DELAY = 100 // ms (원하면 조정 가능)
 
 export const useViewportType = (): ViewportType => {
   const [viewport, setViewport] = useState<ViewportType>('desktop')

--- a/Client/src/layouts/HomeMobileLayout.tsx
+++ b/Client/src/layouts/HomeMobileLayout.tsx
@@ -1,8 +1,17 @@
 import Block from '../components/ui/Block'
 
 import MainInfo from '../components/character/MainInfo'
+import BarrackList from '../components/barracks/BarrackList'
+import { getGoldByLevelRange } from '../utils/expeditionDataUtils'
+import { useExpeditionGoldData } from '../hook/useCharacterGoldData'
+import PieChartComponent from '../components/charts/PieChart'
+import { expeditionColors } from '../styles/colors'
+import LevelRangeList from '../components/barracks/LevelRangeList'
+import GoldDashboard from '../components/GoldDashboard'
 
 const HomeMobileLayout = () => {
+  const expeditionGoldData = getGoldByLevelRange(useExpeditionGoldData() || [])
+
   return (
     <main className='space-y-[10px] p-[10px]'>
       <div className='grid grid-cols-1 place-items-center gap-y-[10px]'>
@@ -11,9 +20,35 @@ const HomeMobileLayout = () => {
             <MainInfo />
           </Block>
         </div>
-        {/* 배럭 리스트 (모바일) */}
         <div className='배럭 리스트'>
-          <Block width={370} height={300} />
+          <Block width={370} height={300}>
+            <BarrackList />
+          </Block>
+        </div>
+        <div className='차트'>
+          <Block width={370} height={230}>
+            <PieChartComponent
+              data={expeditionGoldData}
+              colors={expeditionColors}
+              width={200}
+              height={200}
+              outerRadius={100}
+            />
+          </Block>
+        </div>
+        <div className='LevelRangeList'>
+          <Block width={370} height={220}>
+            <div className='my-auto'>
+              <LevelRangeList />
+            </div>
+          </Block>
+        </div>
+        <div className='GoldDashboard'>
+          <Block width={370} height={220}>
+            <div className='my-auto'>
+              <GoldDashboard />
+            </div>
+          </Block>
         </div>
       </div>
     </main>

--- a/Client/src/layouts/HomeMobileLayout.tsx
+++ b/Client/src/layouts/HomeMobileLayout.tsx
@@ -8,9 +8,12 @@ import PieChartComponent from '../components/charts/PieChart'
 import { expeditionColors } from '../styles/colors'
 import LevelRangeList from '../components/barracks/LevelRangeList'
 import GoldDashboard from '../components/GoldDashboard'
+import Button from '../components/ui/Button'
+import { useNavigate } from 'react-router-dom'
 
 const HomeMobileLayout = () => {
   const expeditionGoldData = getGoldByLevelRange(useExpeditionGoldData() || [])
+  const navigate = useNavigate()
 
   return (
     <main className='space-y-[10px] p-[10px]'>
@@ -25,31 +28,44 @@ const HomeMobileLayout = () => {
             <BarrackList />
           </Block>
         </div>
-        <div className='차트'>
+        {expeditionGoldData.length === 0 ? (
           <Block width={370} height={230}>
-            <PieChartComponent
-              data={expeditionGoldData}
-              colors={expeditionColors}
-              width={200}
-              height={200}
-              outerRadius={100}
-            />
-          </Block>
-        </div>
-        <div className='LevelRangeList'>
-          <Block width={370} height={220}>
-            <div className='my-auto'>
-              <LevelRangeList />
+            <div className='flex w-[90%] flex-col items-center justify-center gap-4 opacity-80'>
+              <h3 className='text-black'>주간 골드 설정을 해주세요</h3>
+              <Button text='설정하기' onClick={() => navigate('/Weekly')} />
             </div>
           </Block>
-        </div>
-        <div className='GoldDashboard'>
-          <Block width={370} height={220}>
-            <div className='my-auto'>
-              <GoldDashboard />
+        ) : (
+          <>
+            <div className='차트'>
+              <Block width={370} height={230}>
+                <PieChartComponent
+                  data={expeditionGoldData}
+                  colors={expeditionColors}
+                  width={200}
+                  height={200}
+                  outerRadius={100}
+                />
+              </Block>
             </div>
-          </Block>
-        </div>
+
+            <div className='LevelRangeList'>
+              <Block width={370} height={220}>
+                <div className='my-auto'>
+                  <LevelRangeList />
+                </div>
+              </Block>
+            </div>
+
+            <div className='GoldDashboard'>
+              <Block width={370} height={220}>
+                <div className='my-auto'>
+                  <GoldDashboard />
+                </div>
+              </Block>
+            </div>
+          </>
+        )}
       </div>
     </main>
   )


### PR DESCRIPTION
## ✨ 기능 추가
- Mobile Layout 내 UI 설정 및 관련 컴포넌트 삽입
- ExpeditionGoldData가 없을 경우 SummaryPreview에서 안내 메세지 표시 기능 추가

## 🔧 패키지 설치
- 없음

## 🎨 프론트엔드 개발
- BarrackList: 기존 고정폭에서 `w-90%`로 가변폭 레이아웃 적용
- PieChart: 차트 랜더링 애니메이션 속도 조정 가능하도록 props 인자 추가
- SummaryPreview: Import 구문 오타 수정

## 🔄 리팩토링
- SummaryPreview 안내문구 표시 조건 및 컴포넌트 분기 처리 개선
- 기타 불필요 import 정리

## 🧪 테스트 및 확인 내역
- MobileLayout 적용 후 모바일 환경에서 레이아웃 및 UI 정상 렌더링 확인
- BarrackList 반응형 폭 조정 후 크기 변경 정상 동작 확인
- PieChart 애니메이션 속도 설정값 변경 테스트 완료
- ExpeditionGoldData 없는 경우 안내 문구 정상 출력 확인
