### PR TITLE
feat: 주간 골드 시각화 차트 기능 구현 및 차트 UI/스타일 개선

### DIFF
--- a/Client/src/components/GoldDashboard.tsx
+++ b/Client/src/components/GoldDashboard.tsx
@@ -23,7 +23,7 @@ const GoldDashboard = ({ width = 312, height = 200, GoldData }: GoldDashboardPro
   return (
     <div
       style={{ width: `${width}px`, height: `${height}px` }}
-      className={`flex flex-col justify-between gap-3 rounded-xl border p-3 ${darkMode ? 'border-black/30' : 'border-gray'}`}
+      className={`flex flex-col justify-between gap-3 rounded-xl border-2 p-3 ${darkMode ? 'border-black/30' : 'border-gray'}`}
     >
       <div className={`flex items-center justify-between`}>
         <h3 className='text-black'>원정대 평균</h3>

--- a/Client/src/components/charts/AreaChart.tsx
+++ b/Client/src/components/charts/AreaChart.tsx
@@ -5,7 +5,6 @@ import {
   Tooltip,
   AreaChart,
   Area,
-  YAxis,
   Legend,
 } from 'recharts'
 import { expeditionGoldData } from '../../types/Types'

--- a/Client/src/components/charts/AreaChart.tsx
+++ b/Client/src/components/charts/AreaChart.tsx
@@ -1,0 +1,61 @@
+import {
+  ResponsiveContainer,
+  CartesianGrid,
+  XAxis,
+  Tooltip,
+  AreaChart,
+  Area,
+  YAxis,
+  Legend,
+} from 'recharts'
+import { expeditionGoldData } from '../../types/Types'
+
+interface AreaChartComponentProps {
+  data: expeditionGoldData[]
+  width?: number
+  height?: number
+}
+
+const AreaChartComponent = ({ data, width = 200, height = 200 }: AreaChartComponentProps) => {
+  // 최대 6주차까지 처리
+  const totalBaseGold = data
+    .slice(0, 6)
+    .reduce((acc, item) => acc + item.raidGold + item.otherGold, 0)
+
+  const chartData = Array.from({ length: 6 }, (_, idx) => {
+    const index = idx + 1
+    return {
+      week: `${index}주차`,
+      totalGold: totalBaseGold * index,
+    }
+  })
+
+  return (
+    <ResponsiveContainer width='100%' height='100%'>
+      <AreaChart width={width} height={height} data={chartData} margin={{ right: 15, left: 15 }}>
+        <CartesianGrid strokeDasharray='3 3' strokeWidth={2.5} />
+        <XAxis dataKey='week' fontSize={12} fontFamily='SUIT' fontWeight={600} interval={0} />
+        <Tooltip
+          itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
+          formatter={(value, name) => {
+            if (name === 'totalGold') return [value, '종합 골드']
+            return [value, name]
+          }}
+        />
+        <Legend
+          payload={[
+            {
+              value: '종합 골드',
+              id: 'totalGold',
+              type: 'square', // ✅ 도형 타입 추가
+              color: '#8884d8', // ✅ 색상 적용됨
+            },
+          ]}
+        />
+        <Area type='monotone' dataKey='totalGold' stackId='a' fill='#8884d8' />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}
+
+export default AreaChartComponent

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -25,6 +25,12 @@ const BarChartComponent = ({
 
         <Tooltip
           itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
+          contentStyle={{
+            border: '2px solid #BEBEBE',
+            borderRadius: '10px',
+            padding: '8px 12px', // 안쪽 여백
+            boxShadow: '0 2px 6px rgba(0,0,0,0.1)', // 시각적 보강
+          }}
           formatter={(value, name) => {
             if (name === 'raidGold') return [value, '레이드 골드']
             if (name === 'otherGold') return [value, '기타 골드']

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -25,7 +25,7 @@ const BarChartComponent = ({
   const colors = darkMode ? darkColor : lightColor
 
   return (
-    <ResponsiveContainer width={width} height={height}>
+    <ResponsiveContainer width='100%' height='100%'>
       <BarChart width={width} height={height} data={data.slice(0, 6)}>
         <CartesianGrid strokeDasharray='3 3' strokeWidth={3} />
         <XAxis dataKey={dataKey} interval={0} fontSize={12} fontFamily='SUIT' fontWeight={600} />

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -31,6 +31,7 @@ const BarChartComponent = ({
         <XAxis dataKey={dataKey} interval={0} fontSize={12} fontFamily='SUIT' fontWeight={600} />
 
         <Tooltip
+          itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
           formatter={(value, name) => {
             if (name === 'raidGold') return [value, '레이드 골드']
             if (name === 'otherGold') return [value, '기타 골드']

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -1,6 +1,5 @@
 import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, Tooltip, Legend, Bar } from 'recharts'
 import { expeditionGoldData } from '../../types/Types'
-import useThemeStore from '../../stores/others/ThemeStore'
 
 interface PieChartComponentProps {
   data: expeditionGoldData[]
@@ -8,8 +7,7 @@ interface PieChartComponentProps {
   width?: number
   height?: number
   dataKey?: string
-  darkColor?: string[]
-  lightColor?: string[]
+  color?: string[]
 }
 
 const BarChartComponent = ({
@@ -17,13 +15,8 @@ const BarChartComponent = ({
   dataKey = 'name',
   width = 200,
   height = 200,
-  darkColor = ['#8884d8', '#F59E0B'],
-  lightColor = ['#8884d8', '#82ca9d'],
+  color = ['#8884d8', '#4BD66E'],
 }: PieChartComponentProps) => {
-  const darkMode = useThemeStore((state) => state.darkMode)
-
-  const colors = darkMode ? darkColor : lightColor
-
   return (
     <ResponsiveContainer width='100%' height='100%'>
       <BarChart width={width} height={height} data={data.slice(0, 6)}>
@@ -40,13 +33,13 @@ const BarChartComponent = ({
         />
         <Legend
           payload={[
-            { value: '레이드 골드', type: 'square', id: 'raidGold', color: colors[0] },
-            { value: '기타 골드', type: 'square', id: 'otherGold', color: colors[1] },
+            { value: '레이드 골드', type: 'square', id: 'raidGold', color: color[0] },
+            { value: '기타 골드', type: 'square', id: 'otherGold', color: color[1] },
           ]}
         />
 
-        <Bar dataKey='raidGold' stackId='a' fill={colors[0]} />
-        <Bar dataKey='otherGold' stackId='a' fill={colors[1]} />
+        <Bar dataKey='raidGold' stackId='a' fill={color[0]} />
+        <Bar dataKey='otherGold' stackId='a' fill={color[1]} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -1,0 +1,54 @@
+import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, Tooltip, Legend, Bar } from 'recharts'
+import { expeditionGoldData } from '../../types/Types'
+import useThemeStore from '../../stores/others/ThemeStore'
+
+interface PieChartComponentProps {
+  data: expeditionGoldData[]
+  colors?: string[]
+  width?: number
+  height?: number
+  dataKey?: string
+  darkColor?: string[]
+  lightColor?: string[]
+}
+
+const BarChartComponent = ({
+  data,
+  dataKey = 'name',
+  width = 200,
+  height = 200,
+  darkColor = ['#8884d8', '#F59E0B'],
+  lightColor = ['#8884d8', '#82ca9d'],
+}: PieChartComponentProps) => {
+  const darkMode = useThemeStore((state) => state.darkMode)
+
+  const colors = darkMode ? darkColor : lightColor
+
+  return (
+    <ResponsiveContainer width={width} height={height}>
+      <BarChart width={width} height={height} data={data.slice(0, 6)}>
+        <CartesianGrid strokeDasharray='3 3' strokeWidth={3} />
+        <XAxis dataKey={dataKey} interval={0} fontSize={12} fontFamily='SUIT' fontWeight={600} />
+
+        <Tooltip
+          formatter={(value, name) => {
+            if (name === 'raidGold') return [value, '레이드 골드']
+            if (name === 'otherGold') return [value, '기타 골드']
+            return [value, name]
+          }}
+        />
+        <Legend
+          payload={[
+            { value: '레이드 골드', type: 'square', id: 'raidGold', color: colors[0] },
+            { value: '기타 골드', type: 'square', id: 'otherGold', color: colors[1] },
+          ]}
+        />
+
+        <Bar dataKey='raidGold' stackId='a' fill={colors[0]} />
+        <Bar dataKey='otherGold' stackId='a' fill={colors[1]} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+export default BarChartComponent

--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -42,6 +42,21 @@ const BarChartComponent = ({
             { value: '레이드 골드', type: 'square', id: 'raidGold', color: color[0] },
             { value: '기타 골드', type: 'square', id: 'otherGold', color: color[1] },
           ]}
+          formatter={(value) => (
+            <span
+              style={{
+                color: '#000',
+                fontFamily: 'SUIT',
+                fontWeight: 500,
+                fontSize: '14px',
+                lineHeight: '14px',
+                verticalAlign: 'middle',
+              }}
+            >
+              {value}
+            </span>
+          )}
+          iconType='square'
         />
 
         <Bar dataKey='raidGold' stackId='a' fill={color[0]} />

--- a/Client/src/components/charts/SingleBarChart.tsx
+++ b/Client/src/components/charts/SingleBarChart.tsx
@@ -34,6 +34,12 @@ const SingleBarChartComponent = ({
         <XAxis dataKey='week' fontSize={12} fontFamily='SUIT' fontWeight={600} interval={0} />
         <Tooltip
           itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
+          contentStyle={{
+            border: '2px solid #BEBEBE',
+            borderRadius: '10px',
+            padding: '8px 12px', // 안쪽 여백
+            boxShadow: '0 2px 6px rgba(0,0,0,0.1)', // 시각적 보강
+          }}
           formatter={(value, name) => {
             if (name === 'totalGold') return [value, '종합 골드']
             return [value, name]

--- a/Client/src/components/charts/SingleBarChart.tsx
+++ b/Client/src/components/charts/SingleBarChart.tsx
@@ -37,8 +37,8 @@ const SingleBarChartComponent = ({
           contentStyle={{
             border: '2px solid #BEBEBE',
             borderRadius: '10px',
-            padding: '8px 12px', // 안쪽 여백
-            boxShadow: '0 2px 6px rgba(0,0,0,0.1)', // 시각적 보강
+            padding: '8px 12px',
+            boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
           }}
           formatter={(value, name) => {
             if (name === 'totalGold') return [value, '종합 골드']
@@ -50,10 +50,26 @@ const SingleBarChartComponent = ({
             {
               value: '종합 골드',
               id: 'totalGold',
-              type: 'square', // ✅ 도형 타입 추가
-              color: color, // ✅ 색상 적용됨
+              type: 'square',
+              color: color,
             },
           ]}
+          formatter={(value) => (
+            <span
+              style={{
+                color: '#000',
+                fontFamily: 'SUIT',
+                fontWeight: 500,
+                fontSize: '14px',
+                lineHeight: '14px',
+                verticalAlign: 'middle',
+                display: 'inline-block',
+              }}
+            >
+              {value}
+            </span>
+          )}
+          iconType='square'
         />
         <Bar type='monotone' dataKey='totalGold' fill={color} />
       </BarChart>

--- a/Client/src/components/charts/SingleBarChart.tsx
+++ b/Client/src/components/charts/SingleBarChart.tsx
@@ -1,21 +1,19 @@
-import {
-  ResponsiveContainer,
-  CartesianGrid,
-  XAxis,
-  Tooltip,
-  AreaChart,
-  Area,
-  Legend,
-} from 'recharts'
+import { ResponsiveContainer, CartesianGrid, XAxis, Tooltip, Legend, BarChart, Bar } from 'recharts'
 import { expeditionGoldData } from '../../types/Types'
 
 interface AreaChartComponentProps {
   data: expeditionGoldData[]
   width?: number
   height?: number
+  color?: string
 }
 
-const AreaChartComponent = ({ data, width = 200, height = 200 }: AreaChartComponentProps) => {
+const SingleBarChartComponent = ({
+  data,
+  width = 200,
+  height = 200,
+  color = '#F59E0B',
+}: AreaChartComponentProps) => {
   // 최대 6주차까지 처리
   const totalBaseGold = data
     .slice(0, 6)
@@ -31,7 +29,7 @@ const AreaChartComponent = ({ data, width = 200, height = 200 }: AreaChartCompon
 
   return (
     <ResponsiveContainer width='100%' height='100%'>
-      <AreaChart width={width} height={height} data={chartData} margin={{ right: 15, left: 15 }}>
+      <BarChart width={width} height={height} data={chartData} margin={{ right: 15, left: 15 }}>
         <CartesianGrid strokeDasharray='3 3' strokeWidth={2.5} />
         <XAxis dataKey='week' fontSize={12} fontFamily='SUIT' fontWeight={600} interval={0} />
         <Tooltip
@@ -47,14 +45,14 @@ const AreaChartComponent = ({ data, width = 200, height = 200 }: AreaChartCompon
               value: '종합 골드',
               id: 'totalGold',
               type: 'square', // ✅ 도형 타입 추가
-              color: '#8884d8', // ✅ 색상 적용됨
+              color: color, // ✅ 색상 적용됨
             },
           ]}
         />
-        <Area type='monotone' dataKey='totalGold' stackId='a' fill='#8884d8' />
-      </AreaChart>
+        <Bar type='monotone' dataKey='totalGold' fill={color} />
+      </BarChart>
     </ResponsiveContainer>
   )
 }
 
-export default AreaChartComponent
+export default SingleBarChartComponent

--- a/Client/src/components/selector/OtherSelector.tsx
+++ b/Client/src/components/selector/OtherSelector.tsx
@@ -75,7 +75,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
   }
 
   return (
-    <div className='flex gap-2'>
+    <div className='mx-auto flex gap-[18px]'>
       {Object.entries(availableOther).map(([key, value]) => {
         const selected = isOtherSelected(value.name)
         const doubled = isDouble[value.name] || false

--- a/Client/src/components/selector/RaidSelector.tsx
+++ b/Client/src/components/selector/RaidSelector.tsx
@@ -184,7 +184,8 @@ const RaidSelector = ({
         <Button text='다음' width={80} onClick={handleNext} />
         <Button text='기타 컨텐츠' width={130} onClick={handleToggleModal} />
         <Modal onClose={handleToggleModal} open={open}>
-          <div className='flex h-[259px] w-[370px] flex-col'>
+          <div className='flex h-[259px] w-[370px] flex-col gap-5 p-4'>
+            <h3 className='leading-none font-extrabold text-black'>기타 컨텐츠 선택</h3>
             <OtherSelector SelectedCharacterInfo={SelectedCharacterInfo} />
           </div>
         </Modal>

--- a/Client/src/components/selector/RaidSelector.tsx
+++ b/Client/src/components/selector/RaidSelector.tsx
@@ -179,7 +179,7 @@ const RaidSelector = ({
           })
           .reverse()}
       </div>
-      <div className='flex w-[322px] justify-between'>
+      <div className='mx-auto flex w-[322px] justify-between'>
         <Button text='이전' width={80} onClick={handlePrev} />
         <Button text='다음' width={80} onClick={handleNext} />
         <Button text='기타 컨텐츠' width={130} onClick={handleToggleModal} />

--- a/Client/src/components/ui/Modal.tsx
+++ b/Client/src/components/ui/Modal.tsx
@@ -25,7 +25,7 @@ const Modal = ({ open, onClose, children, isButton = false }: ModalProps) => {
       className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'
       onClick={handleOverlayClick}
     >
-      <div className='rounded-lg bg-white p-4 shadow-lg' onClick={handleModalContentClick}>
+      <div className='rounded-lg bg-white shadow-lg' onClick={handleModalContentClick}>
         {children}
         {isButton && <Button text='닫기' onClick={onClose} />}
       </div>

--- a/Client/src/layouts/WeeklyDesktopLayout.tsx
+++ b/Client/src/layouts/WeeklyDesktopLayout.tsx
@@ -44,8 +44,10 @@ const WeeklyDesktopLayout = () => {
               </div>
             </div>
           </Block>
-
-          <Block width={694} height={358}></Block>
+          <div className='flex gap-[10px]'>
+            <Block width={342} height={358}></Block>
+            <Block width={342} height={358}></Block>
+          </div>
         </div>
       </main>
     </div>

--- a/Client/src/layouts/WeeklyDesktopLayout.tsx
+++ b/Client/src/layouts/WeeklyDesktopLayout.tsx
@@ -5,6 +5,7 @@ import Block from '../components/ui/Block'
 import { useExpeditionGoldData } from '../hook/useExpeditionGoldData'
 import { useCharacterSelectionStore } from '../stores/selections/CharacterSelectionStore'
 import BarChartComponent from '../components/charts/BarChart'
+import AreaChartComponent from '../components/charts/AreaChart'
 
 const WeeklyDesktopLayout = () => {
   const expeditionGoldData = useExpeditionGoldData() || []
@@ -53,7 +54,12 @@ const WeeklyDesktopLayout = () => {
                 <BarChartComponent width={310} height={284} data={expeditionGoldData} />
               </div>
             </Block>
-            <Block width={342} height={358}></Block>
+            <Block width={342} height={358}>
+              <div className='flex h-full w-full flex-col gap-5 p-4'>
+                <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
+                <AreaChartComponent width={310} height={284} data={expeditionGoldData} />
+              </div>
+            </Block>
           </div>
         </div>
       </main>

--- a/Client/src/layouts/WeeklyDesktopLayout.tsx
+++ b/Client/src/layouts/WeeklyDesktopLayout.tsx
@@ -5,7 +5,7 @@ import Block from '../components/ui/Block'
 import { useExpeditionGoldData } from '../hook/useExpeditionGoldData'
 import { useCharacterSelectionStore } from '../stores/selections/CharacterSelectionStore'
 import BarChartComponent from '../components/charts/BarChart'
-import AreaChartComponent from '../components/charts/AreaChart'
+import SingleBarChartComponent from '../components/charts/SingleBarChart'
 
 const WeeklyDesktopLayout = () => {
   const expeditionGoldData = useExpeditionGoldData() || []
@@ -56,7 +56,7 @@ const WeeklyDesktopLayout = () => {
             <Block width={342} height={358}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-                <AreaChartComponent data={expeditionGoldData} />
+                <SingleBarChartComponent data={expeditionGoldData} />
               </div>
             </Block>
           </div>

--- a/Client/src/layouts/WeeklyDesktopLayout.tsx
+++ b/Client/src/layouts/WeeklyDesktopLayout.tsx
@@ -4,10 +4,12 @@ import RaidSelector from '../components/selector/RaidSelector'
 import Block from '../components/ui/Block'
 import { useExpeditionGoldData } from '../hook/useExpeditionGoldData'
 import { useCharacterSelectionStore } from '../stores/selections/CharacterSelectionStore'
+import BarChartComponent from '../components/charts/BarChart'
 
 const WeeklyDesktopLayout = () => {
   const expeditionGoldData = useExpeditionGoldData() || []
   const SelectedCharacterInfo = useCharacterSelectionStore((state) => state.SelectedCharacterInfo)
+  console.log('expeditionGoldData', expeditionGoldData)
 
   return (
     <div className='min-h-screen bg-gray-600'>
@@ -45,7 +47,12 @@ const WeeklyDesktopLayout = () => {
             </div>
           </Block>
           <div className='flex gap-[10px]'>
-            <Block width={342} height={358}></Block>
+            <Block width={342} height={358}>
+              <div className='flex h-full w-full flex-col gap-5 p-4'>
+                <h3 className='leading-none font-extrabold text-black'> 골드 차트</h3>
+                <BarChartComponent width={310} height={284} data={expeditionGoldData} />
+              </div>
+            </Block>
             <Block width={342} height={358}></Block>
           </div>
         </div>

--- a/Client/src/layouts/WeeklyDesktopLayout.tsx
+++ b/Client/src/layouts/WeeklyDesktopLayout.tsx
@@ -10,7 +10,6 @@ import AreaChartComponent from '../components/charts/AreaChart'
 const WeeklyDesktopLayout = () => {
   const expeditionGoldData = useExpeditionGoldData() || []
   const SelectedCharacterInfo = useCharacterSelectionStore((state) => state.SelectedCharacterInfo)
-  console.log('expeditionGoldData', expeditionGoldData)
 
   return (
     <div className='min-h-screen bg-gray-600'>
@@ -51,13 +50,13 @@ const WeeklyDesktopLayout = () => {
             <Block width={342} height={358}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 골드 차트</h3>
-                <BarChartComponent width={310} height={284} data={expeditionGoldData} />
+                <BarChartComponent data={expeditionGoldData} />
               </div>
             </Block>
             <Block width={342} height={358}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-                <AreaChartComponent width={310} height={284} data={expeditionGoldData} />
+                <AreaChartComponent data={expeditionGoldData} />
               </div>
             </Block>
           </div>

--- a/Client/src/layouts/WeeklyMobileLayout.tsx
+++ b/Client/src/layouts/WeeklyMobileLayout.tsx
@@ -42,6 +42,8 @@ const WeeklyMobileLayout = () => {
               <GoldDashboard width={338} height={196} GoldData={expeditionGoldData} />
             </div>
           </Block>
+          <Block width={370} height={324}></Block>
+          <Block width={370} height={324}></Block>
         </div>
       </main>
     </div>

--- a/Client/src/layouts/WeeklyMobileLayout.tsx
+++ b/Client/src/layouts/WeeklyMobileLayout.tsx
@@ -1,4 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
+import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
 import Block from '../components/ui/Block'
@@ -42,7 +43,12 @@ const WeeklyMobileLayout = () => {
               <GoldDashboard width={338} height={196} GoldData={expeditionGoldData} />
             </div>
           </Block>
-          <Block width={370} height={324}></Block>
+          <Block width={370} height={324}>
+            <div className='flex h-full w-full flex-col gap-5 p-4'>
+              <h3 className='leading-none font-extrabold text-black'> 주간 골드</h3>
+              <BarChartComponent width={338} height={250} data={expeditionGoldData} />
+            </div>
+          </Block>
           <Block width={370} height={324}></Block>
         </div>
       </main>

--- a/Client/src/layouts/WeeklyMobileLayout.tsx
+++ b/Client/src/layouts/WeeklyMobileLayout.tsx
@@ -47,13 +47,13 @@ const WeeklyMobileLayout = () => {
           <Block width={370} height={324}>
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h3 className='leading-none font-extrabold text-black'> 주간 골드</h3>
-              <BarChartComponent width={338} height={250} data={expeditionGoldData} />
+              <BarChartComponent data={expeditionGoldData} />
             </div>
           </Block>
           <Block width={370} height={324}>
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-              <AreaChartComponent width={338} height={250} data={expeditionGoldData} />
+              <AreaChartComponent data={expeditionGoldData} />
             </div>
           </Block>
         </div>

--- a/Client/src/layouts/WeeklyMobileLayout.tsx
+++ b/Client/src/layouts/WeeklyMobileLayout.tsx
@@ -1,4 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
+import AreaChartComponent from '../components/charts/AreaChart'
 import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
@@ -49,7 +50,12 @@ const WeeklyMobileLayout = () => {
               <BarChartComponent width={338} height={250} data={expeditionGoldData} />
             </div>
           </Block>
-          <Block width={370} height={324}></Block>
+          <Block width={370} height={324}>
+            <div className='flex h-full w-full flex-col gap-5 p-4'>
+              <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
+              <AreaChartComponent width={338} height={250} data={expeditionGoldData} />
+            </div>
+          </Block>
         </div>
       </main>
     </div>

--- a/Client/src/layouts/WeeklyMobileLayout.tsx
+++ b/Client/src/layouts/WeeklyMobileLayout.tsx
@@ -1,5 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
-import AreaChartComponent from '../components/charts/AreaChart'
+import SingleBarChartComponent from '../components/charts/SingleBarChart'
 import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
@@ -53,7 +53,7 @@ const WeeklyMobileLayout = () => {
           <Block width={370} height={324}>
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-              <AreaChartComponent data={expeditionGoldData} />
+              <SingleBarChartComponent data={expeditionGoldData} />
             </div>
           </Block>
         </div>

--- a/Client/src/layouts/WeeklyTabletLayout.tsx
+++ b/Client/src/layouts/WeeklyTabletLayout.tsx
@@ -1,4 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
+import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
 import Block from '../components/ui/Block'
@@ -45,7 +46,12 @@ const WeeklyTabletLayout = () => {
             </Block>
           </div>
           <div className='flex flex-col gap-[10px]'>
-            <Block width={439} height={329}></Block>
+            <Block width={439} height={329}>
+              <div className='flex h-full w-full flex-col gap-5 p-4'>
+                <h3 className='leading-none font-extrabold text-black'> 골드 차트</h3>
+                <BarChartComponent data={expeditionGoldData} width={407} height={255} />
+              </div>
+            </Block>
             <Block width={439} height={328}></Block>
           </div>
         </div>

--- a/Client/src/layouts/WeeklyTabletLayout.tsx
+++ b/Client/src/layouts/WeeklyTabletLayout.tsx
@@ -1,4 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
+import AreaChartComponent from '../components/charts/AreaChart'
 import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
@@ -52,7 +53,12 @@ const WeeklyTabletLayout = () => {
                 <BarChartComponent data={expeditionGoldData} width={407} height={255} />
               </div>
             </Block>
-            <Block width={439} height={328}></Block>
+            <Block width={439} height={328}>
+              <div className='flex h-full w-full flex-col gap-5 p-4'>
+                <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
+                <AreaChartComponent width={407} height={254} data={expeditionGoldData} />
+              </div>
+            </Block>
           </div>
         </div>
       </main>

--- a/Client/src/layouts/WeeklyTabletLayout.tsx
+++ b/Client/src/layouts/WeeklyTabletLayout.tsx
@@ -45,7 +45,8 @@ const WeeklyTabletLayout = () => {
             </Block>
           </div>
           <div className='flex flex-col gap-[10px]'>
-            <Block width={439} height={667}></Block>
+            <Block width={439} height={329}></Block>
+            <Block width={439} height={328}></Block>
           </div>
         </div>
       </main>

--- a/Client/src/layouts/WeeklyTabletLayout.tsx
+++ b/Client/src/layouts/WeeklyTabletLayout.tsx
@@ -1,5 +1,5 @@
 import BarrackList from '../components/barracks/BarrackList'
-import AreaChartComponent from '../components/charts/AreaChart'
+import SingleBarChartComponent from '../components/charts/SingleBarChart'
 import BarChartComponent from '../components/charts/BarChart'
 import GoldDashboard from '../components/GoldDashboard'
 import RaidSelector from '../components/selector/RaidSelector'
@@ -56,7 +56,7 @@ const WeeklyTabletLayout = () => {
             <Block width={439} height={328}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-                <AreaChartComponent data={expeditionGoldData} />
+                <SingleBarChartComponent data={expeditionGoldData} />
               </div>
             </Block>
           </div>

--- a/Client/src/layouts/WeeklyTabletLayout.tsx
+++ b/Client/src/layouts/WeeklyTabletLayout.tsx
@@ -50,13 +50,13 @@ const WeeklyTabletLayout = () => {
             <Block width={439} height={329}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 골드 차트</h3>
-                <BarChartComponent data={expeditionGoldData} width={407} height={255} />
+                <BarChartComponent data={expeditionGoldData} />
               </div>
             </Block>
             <Block width={439} height={328}>
               <div className='flex h-full w-full flex-col gap-5 p-4'>
                 <h3 className='leading-none font-extrabold text-black'> 주차별 골드 예상치</h3>
-                <AreaChartComponent width={407} height={254} data={expeditionGoldData} />
+                <AreaChartComponent data={expeditionGoldData} />
               </div>
             </Block>
           </div>


### PR DESCRIPTION
## ✨ 기능 추가
- `raidGold`, `otherGold`, `totalGold` 데이터를 기반으로 한 바 차트, 싱글 바 차트 구현
- 모바일/태블릿 WeeklyGold 페이지에도 차트 컴포넌트 적용

---

## 🎨 프론트엔드 개발
- BarChart, AreaChart 등 차트에 ResponsiveContainer 적용
- Tooltip 디자인 수정: border, box-shadow, 텍스트 색상/크기 통일
- 차트 Legend의 폰트 스타일 및 간격 정리
- 차트와 관련된 섹션 간 구획 분리 (골드 차트 및 주차별 골드 예상치)

---

## 🔄 리팩토링
- BarChart 내 legend, label, tooltip 스타일 통일 및 간격 조정
- ResponsiveContainer 내부의 width/height 중복 설정 제거
- chart 관련 불필요한 import 제거

---

## 🧪 테스트 및 확인 내역
- 차트 반응형 확인 (Mobile / Tablet / Desktop)
- 툴팁/범례 정상 출력 및 스타일 확인
- Selector 내 버튼 중앙 정렬 정상 작동 여부 확인