### PR TITLE
feat: 회원 탈퇴 기능 및 관련 API, UI 컴포넌트 구현

### DIFF
--- a/Client/src/api/userApi.ts
+++ b/Client/src/api/userApi.ts
@@ -102,3 +102,16 @@ export const getApiKey = () => {
 
   return apiKey
 }
+
+export const requestDeleteUser = async (email: string) => {
+  try {
+    const response = await axios.delete(`/api/users/delete/${email}`)
+    localStorage.clear()
+    sessionStorage.clear()
+    console.log('✅ 회원 탈퇴 성공:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('❌ 회원 탈퇴 실패:', error)
+    throw error
+  }
+}

--- a/Client/src/components/form/DeleteUserForm.tsx
+++ b/Client/src/components/form/DeleteUserForm.tsx
@@ -1,0 +1,43 @@
+import { useNavigate } from 'react-router-dom'
+import { requestDeleteUser } from '../../api/userApi'
+import useAccountStore from '../../stores/others/AccountStore'
+import Button from '../ui/Button'
+
+const DeleteUserForm = () => {
+  const navigate = useNavigate()
+  const email = useAccountStore((state) => state.email)
+
+  const handleDeleteUser = async () => {
+    const confirmDelete = window.confirm('정말로 탈퇴하시겠습니까?')
+    if (!confirmDelete) return
+
+    if (!email) {
+      alert('이메일 정보가 없습니다. 다시 로그인해주세요.')
+      return
+    }
+    try {
+      await requestDeleteUser(email)
+      navigate('/login')
+    } catch (error) {
+      console.error('회원 탈퇴 실패:', error)
+      alert('회원 탈퇴 중 오류가 발생했습니다.')
+    } finally {
+      window.location.reload()
+      alert('회원 탈퇴가 완료되었습니다.')
+    }
+  }
+
+  return (
+    <div className='flex flex-col'>
+      <Button
+        type='button'
+        text='회원 탈퇴'
+        onClick={handleDeleteUser}
+        lightColor='bg-red'
+        darkColor='bg-black'
+      />
+    </div>
+  )
+}
+
+export default DeleteUserForm

--- a/Client/src/components/form/UserinfoForm.tsx
+++ b/Client/src/components/form/UserinfoForm.tsx
@@ -3,9 +3,7 @@ import { useState } from 'react'
 import Button from '../ui/Button'
 import Input from '../ui/Input'
 import ErrorText from '../ui/ErrorText'
-
 import { AuthFormData } from '../../types/Types'
-
 import {
   validateCharacterName,
   validateApiKey,
@@ -146,17 +144,9 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
       </div>
       <ErrorText message={errors.character?.message} />
 
-      <div className='mt-2 flex flex-col gap-2'>
+      <div className='mt-2 flex flex-col'>
         {/* 변경 사항 저장 */}
         <Button type='submit' text={isLoading ? '처리중...' : '변경 적용'} disabled={isLoading} />
-        {/* 회원 삭제 */}
-        <Button
-          type='submit'
-          text={isLoading ? '처리중...' : '회원 삭제'}
-          disabled={isLoading}
-          lightColor='bg-red'
-          darkColor='bg-black'
-        />
       </div>
     </form>
   )

--- a/Client/src/pages/Login.tsx
+++ b/Client/src/pages/Login.tsx
@@ -13,6 +13,7 @@ const Login = () => {
 
   const setApiKey = useAccountStore((state) => state.setApiKey)
   const setCharacter = useAccountStore((state) => state.setCharacter)
+  const setEmail = useAccountStore((state) => state.setEmail)
 
   // 비로그인시만 접근가능 (로그인, 게스트시 메인페이지 리다이렉트)
   useRequireNoAuth()
@@ -24,6 +25,7 @@ const Login = () => {
 
       setApiKey(respone.user.apiKey)
       setCharacter(respone.user.character)
+      setEmail(respone.user.email)
 
       sessionStorage.clear()
 

--- a/Client/src/pages/Userinfo.tsx
+++ b/Client/src/pages/Userinfo.tsx
@@ -6,6 +6,7 @@ import useAccountStore from '../stores/others/AccountStore'
 import { requestProfileUpdate } from '../api/userApi'
 import UserinfoForm from '../components/form/UserinfoForm'
 import { useRequireUser } from '../hook/useAuthRedirect'
+import DeleteUserForm from '../components/form/DeleteUserForm'
 
 const Userinfo = () => {
   const [isLoading, setIsLoading] = useState(false)
@@ -47,9 +48,12 @@ const Userinfo = () => {
       <main className='w-full space-y-[10px] p-[10px]'>
         <div className='flex w-full justify-center gap-x-[10px]'>
           <Block width={390} height={310}>
-            <div className='flex h-full w-full flex-col gap-5 p-4'>
+            <div className='flex w-full flex-col gap-5 p-4'>
               <h2 className='mx-auto leading-none font-extrabold text-black'>회원 수정</h2>
-              <UserinfoForm onSubmit={handleProfileSubmit} isLoading={isLoading} />
+              <div className='flex flex-col gap-2'>
+                <UserinfoForm onSubmit={handleProfileSubmit} isLoading={isLoading} />
+                <DeleteUserForm />
+              </div>
             </div>
           </Block>
         </div>

--- a/Client/src/stores/others/AccountStore.ts
+++ b/Client/src/stores/others/AccountStore.ts
@@ -2,17 +2,21 @@ import { persist } from 'zustand/middleware'
 import { create } from 'zustand'
 
 interface accountStoreState {
+  email: string
   apiKey: string
   character: string
   setApiKey: (apiKey: string) => void
   setCharacter: (character: string) => void
+  setEmail: (email: string) => void
 }
 
 const useAccountStore = create<accountStoreState>()(
   persist(
     (set) => ({
+      email: '',
       apiKey: '',
       character: '',
+      setEmail: (email) => set({ email }),
       setApiKey: (apiKey) => set({ apiKey }),
       setCharacter: (character) => set({ character }),
     }),

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -17,6 +17,7 @@ usersRouter.use('/login', require('./routes/login'))
 usersRouter.use('/userinfo', require('./routes/userinfo'))
 usersRouter.use('/find-password', require('./routes/find-password'))
 usersRouter.use('/weekly-gold', require('./routes/weekly-gold'))
+usersRouter.use('/delete', require('./routes/delete-user'))
 app.use('/api/users', usersRouter)
 
 // 정적 파일

--- a/Server/src/routes/delete-user.js
+++ b/Server/src/routes/delete-user.js
@@ -1,0 +1,21 @@
+const express = require('express')
+const router = express.Router()
+const { User } = require('../models')
+
+router.delete('/:email', async (req, res) => {
+  const { email } = req.params
+
+  try {
+    const deleted = await User.destroy({ where: { email } })
+    if (!deleted) {
+      return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' })
+    }
+
+    res.status(200).json({ message: '회원 탈퇴가 완료되었습니다.' })
+  } catch (error) {
+    console.error('❌ 회원 삭제 실패:', error)
+    res.status(500).json({ message: '서버 오류가 발생했습니다.' })
+  }
+})
+
+module.exports = router

--- a/Server/src/routes/login.js
+++ b/Server/src/routes/login.js
@@ -37,6 +37,7 @@ router.post('/', async (req, res) => {
       message: '로그인 성공',
       token: token,
       user: {
+        email: user.email,
         character: user.character,
         apiKey: user.apiKey,
       },


### PR DESCRIPTION
## ✨ 기능 추가
- 로그인 완료 시 response의 email 값을 account-storage에 저장하도록 기능 추가
  - accountStore에 email state 및 setEmail 함수 추가
  - 로그인 성공 응답에 user 이메일 포함 처리
- 회원 탈퇴 API 엔드포인트 구현 및 관련 requestDeleteUser API 함수 작성
- 회원 탈퇴 기능을 위한 DeleteUserForm 컴포넌트 추가 및 Userinfo 페이지에 삽입
- 회원 삭제 라우터 '/delete' 경로 추가


## 🧪 테스트 및 확인 내역
- 로그인 후 email 저장 정상 동작 확인
- 회원 탈퇴 API 요청 정상 작동 및 UI에서 회원 탈퇴 가능 확인
- Userinfo 페이지 내 UI/UX 일관성 유지 확인
