### PR TITLE
[fix/refactor] OtherSelector 내 상태 전역화 및 드롭다운 UI 개선 

### DIFF
--- a/Client/src/components/charts/BarChart.tsx
+++ b/Client/src/components/charts/BarChart.tsx
@@ -24,12 +24,21 @@ const BarChartComponent = ({
         <XAxis dataKey={dataKey} interval={0} fontSize={12} fontFamily='SUIT' fontWeight={600} />
 
         <Tooltip
-          itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
+          itemStyle={{ color: '#000', fontSize: 14, fontFamily: 'SUIT', fontWeight: 500 }}
           contentStyle={{
             border: '2px solid #BEBEBE',
             borderRadius: '10px',
-            padding: '8px 12px', // 안쪽 여백
-            boxShadow: '0 2px 6px rgba(0,0,0,0.1)', // 시각적 보강
+            padding: '0px 12px',
+            boxShadow: '0 2px 6px rgba(0,0,0,0.5)', // 그림자 추가
+          }}
+          labelStyle={{
+            color: '#000',
+            fontSize: 14,
+            fontFamily: 'SUIT',
+            fontWeight: 700,
+
+            marginBottom: '4px',
+            marginTop: '8px',
           }}
           formatter={(value, name) => {
             if (name === 'raidGold') return [value, '레이드 골드']

--- a/Client/src/components/charts/SingleBarChart.tsx
+++ b/Client/src/components/charts/SingleBarChart.tsx
@@ -33,12 +33,21 @@ const SingleBarChartComponent = ({
         <CartesianGrid strokeDasharray='3 3' strokeWidth={2.5} />
         <XAxis dataKey='week' fontSize={12} fontFamily='SUIT' fontWeight={600} interval={0} />
         <Tooltip
-          itemStyle={{ color: '#000', fontSize: 16, fontFamily: 'SUIT', fontWeight: 500 }}
+          itemStyle={{ color: '#000', fontSize: 14, fontFamily: 'SUIT', fontWeight: 500 }}
           contentStyle={{
             border: '2px solid #BEBEBE',
             borderRadius: '10px',
             padding: '8px 12px',
-            boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+            boxShadow: '0 2px 6px rgba(0,0,0,0.5)',
+          }}
+          labelStyle={{
+            color: '#000',
+            fontSize: 14,
+            fontFamily: 'SUIT',
+            fontWeight: 700,
+
+            marginBottom: '4px',
+            marginTop: '4px',
           }}
           formatter={(value, name) => {
             if (name === 'totalGold') return [value, '종합 골드']

--- a/Client/src/components/selector/OtherSelector.tsx
+++ b/Client/src/components/selector/OtherSelector.tsx
@@ -6,6 +6,7 @@ import { getAvailableOthersByLevel } from '../../utils/expeditionDataUtils'
 import { calculateGoldByDrops } from '../../utils/MarketDataUtils'
 import Checkbox from '../ui/CheckBox'
 import Dropdown from '../ui/DropDown'
+import { OtherInfo } from '../../types/Types'
 
 const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }) => {
   const darkMode = useThemeStore((state) => state.darkMode)
@@ -62,15 +63,15 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
 
     // store 상태도 동기화
     if (isOtherSelected(value.name)) {
-      updateSelectionState(
-        SelectedCharacterInfo.name,
-        value.name,
-        value.type,
-        value.level,
-        value.drops,
-        currentDouble,
-        currentMultiplier,
-      )
+      const info: OtherInfo = {
+        name: value.name,
+        type: value.type,
+        level: value.level,
+        drops: value.drops,
+        isDouble: currentDouble,
+        multiplier: currentMultiplier,
+      }
+      updateSelectionState(SelectedCharacterInfo.name, info)
     }
   }
 
@@ -82,6 +83,15 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
 
         const defaultDrop = value.drops
         const currentDrop = character?.selections.find((s) => s.name === value.name)?.drops || []
+
+        const info: OtherInfo = {
+          name: value.name,
+          type: value.type,
+          level: value.level,
+          drops: value.drops,
+          isDouble: doubled,
+          multiplier: multiplier[value.name] || 1,
+        }
 
         return (
           <div key={key} className='flex items-center'>
@@ -101,17 +111,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
                   <div className='ml-auto h-full'>
                     <Checkbox
                       checked={selected}
-                      onChange={() =>
-                        toggleDrops(
-                          SelectedCharacterInfo.name,
-                          value.name,
-                          value.type,
-                          value.level,
-                          value.drops,
-                          doubled,
-                          multiplier[value.name] || 1,
-                        )
-                      }
+                      onChange={() => toggleDrops(SelectedCharacterInfo.name, info)}
                     />
                   </div>
                 </div>

--- a/Client/src/components/selector/OtherSelector.tsx
+++ b/Client/src/components/selector/OtherSelector.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useMarketStore } from '../../stores/api/MarketStore'
 import useThemeStore from '../../stores/others/ThemeStore'
 import { useOtherSelectionStore } from '../../stores/selections/OtherSelectionStore'
@@ -13,16 +12,14 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
   const { toggleDrops, updateSelectionState, characterSelections } = useOtherSelectionStore()
   const itemInfos = useMarketStore((state) => state.itemInfos)
 
-  // 기타 컨텐츠의 휴식 게이지 및 시행횟수 상태
-  const [isDouble, setIsDouble] = useState<{ [key: string]: boolean }>({})
-  const [multiplier, setMultiplier] = useState<{ [key: string]: number }>({})
-
   // 선택한 캐릭터가 선택가능한 other 컨텐츠 목록 불러오기
   const availableOther = getAvailableOthersByLevel(
     parseFloat(SelectedCharacterInfo?.level.replace(/,/g, '') || '0'),
   )
 
   const character = characterSelections.find((c) => c.characterName === SelectedCharacterInfo.name)
+  const isDouble = character?.selections.find((c) => c.isDouble)?.isDouble ?? false
+  const multiplier = character?.selections.find((c) => c.multiplier)?.multiplier ?? 1
 
   // 선택 여부 확인 함수
   const isOtherSelected = (name: string) => {
@@ -33,43 +30,30 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
     return character.selections.some((s) => s.name === name)
   }
 
-  // 휴식게이지 및 시행횟수 상태 동기화 함수
-  const handleOptionChange = (
-    value: any,
-    options: {
-      double?: boolean
-      multiplier?: number
-    },
-  ) => {
-    const { double, multiplier: newMultiplier } = options
-
-    const currentDouble = double ?? isDouble[value.name]
-    const currentMultiplier = newMultiplier ?? (multiplier[value.name] || 1)
-
-    // 상태 업데이트
-    if (double !== undefined) {
-      setIsDouble((prev) => ({
-        ...prev,
-        [value.name]: double,
-      }))
-    }
-
-    if (newMultiplier !== undefined) {
-      setMultiplier((prev) => ({
-        ...prev,
-        [value.name]: newMultiplier,
-      }))
-    }
-
-    // store 상태도 동기화
+  const toggleIsDouble = (value: any, isDouble: boolean) => {
     if (isOtherSelected(value.name)) {
       const info: OtherInfo = {
         name: value.name,
         type: value.type,
         level: value.level,
         drops: value.drops,
-        isDouble: currentDouble,
-        multiplier: currentMultiplier,
+        isDouble: !isDouble,
+        multiplier: multiplier,
+      }
+
+      updateSelectionState(SelectedCharacterInfo.name, info)
+    }
+  }
+
+  const toggleMultiplier = (value: any, multiplier: number) => {
+    if (isOtherSelected(value.name)) {
+      const info: OtherInfo = {
+        name: value.name,
+        type: value.type,
+        level: value.level,
+        drops: value.drops,
+        isDouble: isDouble,
+        multiplier: multiplier,
       }
       updateSelectionState(SelectedCharacterInfo.name, info)
     }
@@ -79,18 +63,23 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
     <div className='mx-auto flex gap-[18px]'>
       {Object.entries(availableOther).map(([key, value]) => {
         const selected = isOtherSelected(value.name)
-        const doubled = isDouble[value.name] || false
 
         const defaultDrop = value.drops
-        const currentDrop = character?.selections.find((s) => s.name === value.name)?.drops || []
+        const dropByName = character?.selections.find((s) => s.name === value.name)?.drops ?? []
+
+        const isDoubleByName =
+          character?.selections.find((s) => s.name === value.name)?.isDouble ?? false
+
+        const multiplierByName =
+          character?.selections.find((s) => s.name === value.name)?.multiplier ?? 1
 
         const info: OtherInfo = {
           name: value.name,
           type: value.type,
           level: value.level,
           drops: value.drops,
-          isDouble: doubled,
-          multiplier: multiplier[value.name] || 1,
+          isDouble: value.isDouble,
+          multiplier: value.multiplier,
         }
 
         return (
@@ -119,25 +108,26 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
                   <h5 className='font-bold text-black'>휴식게이지 적용 </h5>
                   <div className='ml-auto h-full'>
                     <Checkbox
-                      checked={doubled}
-                      onChange={() => handleOptionChange(value, { double: !doubled })}
+                      checked={isDoubleByName}
+                      onChange={() => toggleIsDouble(value, isDouble)}
                     />
                   </div>
                 </div>
                 <div className='flex w-full justify-between gap-1'>
                   <h5 className='font-bold text-black'>시행 횟수 </h5>
                   <Dropdown
-                    width={40}
+                    width={20}
                     height={20}
                     options={['1', '2', '3', '4', '5', '6', '7']}
-                    onSelect={(v) => handleOptionChange(value, { multiplier: parseInt(v) })}
+                    onSelect={(multiplier) => toggleMultiplier(value, Number(multiplier))}
+                    placeholder={multiplierByName.toString()}
                   />
                 </div>
               </div>
               <div className='mt-auto flex w-full justify-end'>
                 <h5 className='font-bold text-black'>종합 </h5>
                 <h5 className='ml-1 font-bold text-black'>
-                  {calculateGoldByDrops(currentDrop, itemInfos).toLocaleString()}G
+                  {calculateGoldByDrops(dropByName, itemInfos).toLocaleString()}G
                 </h5>
               </div>
             </div>

--- a/Client/src/components/selector/RaidSelector.tsx
+++ b/Client/src/components/selector/RaidSelector.tsx
@@ -171,7 +171,7 @@ const RaidSelector = ({
                 </div>
 
                 <div className='mt-auto flex justify-end'>
-                  <h5 className='mr-1 font-bold text-black'>종합</h5>
+                  <h5 className='mr-1 font-bold text-black'>총</h5>
                   <h5 className='font-bold text-black'>{totalGold.toLocaleString()}G</h5>
                 </div>
               </div>

--- a/Client/src/components/ui/DropDown.tsx
+++ b/Client/src/components/ui/DropDown.tsx
@@ -9,7 +9,7 @@ interface DropdownProps {
   placeholder?: string
 }
 
-const Dropdown = ({ width, height, options, onSelect, placeholder = '' }: DropdownProps) => {
+const Dropdown = ({ width, height, options, onSelect, placeholder }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
 
@@ -24,12 +24,10 @@ const Dropdown = ({ width, height, options, onSelect, placeholder = '' }: Dropdo
   return (
     <div style={{ width, height, position: 'relative' }}>
       <div
-        className={`flex h-full w-full cursor-pointer items-center justify-between rounded border-2 p-2 ${darkMode ? 'border-black/20' : 'border-gray'}`}
+        className={`flex h-full w-full cursor-pointer items-center justify-center rounded border-2 ${darkMode ? 'border-black/20' : 'border-gray'}`}
         onClick={() => setIsOpen((prev) => !prev)}
       >
-        <h5 className='flex shrink-0 justify-center font-bold text-black'>
-          {selected || placeholder}
-        </h5>
+        <h5 className='shrink-0 font-bold text-black'>{selected || placeholder}</h5>
       </div>
 
       {isOpen && (
@@ -37,7 +35,7 @@ const Dropdown = ({ width, height, options, onSelect, placeholder = '' }: Dropdo
           {options.map((option) => (
             <h5
               key={option}
-              className='bg-white p-2 font-bold text-black'
+              className='flex justify-center bg-white p-2 font-bold text-black'
               onClick={() => handleSelect(option)}
             >
               {option}

--- a/Client/src/constants/goldOtherTable.ts
+++ b/Client/src/constants/goldOtherTable.ts
@@ -10,6 +10,8 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 457 },
       { name: '1레벨 겁화의 보석', amount: 2 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '쿠르잔2',
@@ -20,6 +22,8 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 519 },
       { name: '1레벨 겁화의 보석', amount: 4 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '쿠르잔3',
@@ -30,17 +34,20 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 642 },
       { name: '1레벨 겁화의 보석', amount: 5 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '네프타1',
     type: '전선',
     level: 1700,
-
     drops: [
       { name: '운명의 파괴석', amount: 278 },
       { name: '운명의 수호석', amount: 845 },
       { name: '1레벨 겁화의 보석', amount: 5 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '아게오로스',
@@ -51,6 +58,8 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 288 },
       { name: '운명의 돌파석', amount: 12 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '스콜라키아',
@@ -61,6 +70,8 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 430 },
       { name: '운명의 돌파석', amount: 18 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
   {
     name: '드렉탈라스',
@@ -71,5 +82,7 @@ export const goldOtherTable: OtherInfo[] = [
       { name: '운명의 수호석', amount: 550 },
       { name: '운명의 돌파석', amount: 20 },
     ],
+    isDouble: false,
+    multiplier: 1,
   },
 ]

--- a/Client/src/stores/selections/OtherSelectionStore.ts
+++ b/Client/src/stores/selections/OtherSelectionStore.ts
@@ -1,27 +1,11 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { OtherSelection, DropInfo, OtherInfo } from '../../types/Types'
+import { OtherSelection, OtherInfo } from '../../types/Types'
 
 interface OtherSelectionState {
   characterSelections: OtherSelection[]
-  toggleDrops: (
-    characterName: string,
-    name: string,
-    type: '전선' | '카게' | '가토',
-    level: number,
-    drops: DropInfo[],
-    isDouble: boolean,
-    multiplier: number,
-  ) => void
-  updateSelectionState: (
-    characterName: string,
-    name: string,
-    type: '전선' | '카게' | '가토',
-    level: number,
-    drops: DropInfo[],
-    isDouble: boolean,
-    multiplier: number,
-  ) => void
+  toggleDrops: (characterName: string, info: OtherInfo) => void
+  updateSelectionState: (characterName: string, info: OtherInfo) => void
   clearSelectionsForCharacter: (characterName: string) => void
   clearAllSelections: () => void
 }
@@ -31,8 +15,9 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
     (set, get) => ({
       characterSelections: [],
 
-      toggleDrops: (characterName, name, type, level, drops, isDouble = false, multiplier = 1) => {
+      toggleDrops: (characterName, info) => {
         const { characterSelections } = get()
+        const { name, type, level, drops, isDouble, multiplier } = info
 
         const character = characterSelections.find((c) => c.characterName === characterName)
 
@@ -122,16 +107,9 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
       },
 
       // 새로운 덮어쓰기 함수
-      updateSelectionState: (
-        characterName,
-        name,
-        type,
-        level,
-        dropsToUpdate,
-        isDouble = false,
-        multiplier = 1,
-      ) => {
+      updateSelectionState: (characterName, info) => {
         const { characterSelections } = get()
+        const { name, type, level, drops, isDouble, multiplier } = info
 
         const character = characterSelections.find((c) => c.characterName === characterName)
 
@@ -150,7 +128,7 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
           s.name === name && s.type === type && s.level === level
             ? {
                 ...s,
-                drops: dropsToUpdate.map((drop) => ({
+                drops: drops.map((drop) => ({
                   ...drop,
                   amount: calcFinalAmount(drop.amount),
                 })),

--- a/Client/src/stores/selections/OtherSelectionStore.ts
+++ b/Client/src/stores/selections/OtherSelectionStore.ts
@@ -132,6 +132,8 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
                   ...drop,
                   amount: calcFinalAmount(drop.amount),
                 })),
+                isDouble,
+                multiplier,
               }
             : s,
         )

--- a/Client/src/stores/selections/OtherSelectionStore.ts
+++ b/Client/src/stores/selections/OtherSelectionStore.ts
@@ -84,6 +84,8 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
                   ...drop,
                   amount: calcFinalAmount(drop.amount),
                 })),
+                isDouble,
+                multiplier,
               },
             ]
           }
@@ -109,6 +111,8 @@ export const useOtherSelectionStore = create<OtherSelectionState>()(
                       ...drop,
                       amount: calcFinalAmount(drop.amount),
                     })),
+                    isDouble,
+                    multiplier,
                   },
                 ],
               },

--- a/Client/src/types/Types.ts
+++ b/Client/src/types/Types.ts
@@ -25,6 +25,8 @@ export interface OtherInfo {
   type: '전선' | '카게' | '가토'
   level: number
   drops: DropInfo[]
+  isDouble: boolean
+  multiplier: number
 }
 
 export interface DropInfo {

--- a/Client/src/utils/expeditionDataUtils.ts
+++ b/Client/src/utils/expeditionDataUtils.ts
@@ -112,6 +112,8 @@ export const getAvailableOthersByLevel = (targetLevel: number): OtherInfo[] => {
           type: item.type,
           level: item.level,
           drops: item.drops,
+          isDouble: item.isDouble,
+          multiplier: item.multiplier,
         })
       }
       return acc


### PR DESCRIPTION
## ✨ 기능 추가
- `OtherInfo` 타입에 `isDouble`, `multiplier` 필드 추가
- `getAvailableOthersByLevel` 함수에서 `isDouble`, `multiplier` 값을 포함하도록 수정

## 🔄 리팩토링
- `OtherSelectionStore` 및 `OtherSelector`에서 매개변수 구조 개선 (`type.ts`의 `OtherInfo` 구조 기반)

## 🎨 프론트엔드 개발
- 드롭다운 컴포넌트의 크기 조정 및 내부 폰트 위치를 정중앙으로 수정
- 바 차트 툴팁 디자인 개선:  
  - 라벨 추가  
  - 그림자 값 조정  
  - 폰트 크기 조정

## 🧪 테스트 및 확인 내역
- `OtherSelector`의 `isDouble`, `multiplier`를 로컬 상태 → `zustand` 전역 상태로 변경하여 연동 정상 작동 확인
- `RaidSelector` 내 '종합' → '총'으로 명칭 변경 반영 여부 확인
