### PR TITLE
refactor: 재련 재료 및 보석 아이템 조회 로직 개선

### DIFF
--- a/Client/src/api/loaApi.ts
+++ b/Client/src/api/loaApi.ts
@@ -58,8 +58,8 @@ export const getItemData = async (
 export const getItemsByCategory = async (
   apikey: string,
   CategoryCode: number,
-  pageNo?: number,
   ItemTier?: number,
+  pageNo?: number,
 ) => {
   try {
     const instance = createLostarkInstance(apikey)

--- a/Client/src/api/loaApi.ts
+++ b/Client/src/api/loaApi.ts
@@ -55,7 +55,12 @@ export const getItemData = async (
   }
 }
 
-export const getItemsByCategory = async (apikey: string, CategoryCode: number, pageNo?: number) => {
+export const getItemsByCategory = async (
+  apikey: string,
+  CategoryCode: number,
+  pageNo?: number,
+  ItemTier?: number,
+) => {
   try {
     const instance = createLostarkInstance(apikey)
     const res = await instance.post('markets/items', {
@@ -63,6 +68,7 @@ export const getItemsByCategory = async (apikey: string, CategoryCode: number, p
       CategoryCode: CategoryCode,
       SortCondition: 'ASC',
       PageNo: pageNo || 1,
+      ItemTier: ItemTier || null,
     })
     // console.log(`✅ ${CategoryCode} 카테고리코드의 아이템 정보`)
 

--- a/Client/src/api/loaApi.ts
+++ b/Client/src/api/loaApi.ts
@@ -55,6 +55,23 @@ export const getItemData = async (
   }
 }
 
+export const getItemsByCategory = async (apikey: string, CategoryCode: number) => {
+  try {
+    const instance = createLostarkInstance(apikey)
+    const res = await instance.post('markets/items', {
+      Sort: 'GRADE',
+      CategoryCode: CategoryCode,
+      SortCondition: 'ASC',
+      PageNo: 1,
+    })
+    // console.log(`✅ ${CategoryCode} 카테고리코드의 아이템 정보`)
+
+    return res.data
+  } catch (error) {
+    console.error(`❌ ${CategoryCode} 카테고리코드 오류`, error)
+  }
+}
+
 export const getJewelData = async (apikey: string, Name: string) => {
   try {
     const instance = createLostarkInstance(apikey)

--- a/Client/src/api/loaApi.ts
+++ b/Client/src/api/loaApi.ts
@@ -55,14 +55,14 @@ export const getItemData = async (
   }
 }
 
-export const getItemsByCategory = async (apikey: string, CategoryCode: number) => {
+export const getItemsByCategory = async (apikey: string, CategoryCode: number, pageNo?: number) => {
   try {
     const instance = createLostarkInstance(apikey)
     const res = await instance.post('markets/items', {
       Sort: 'GRADE',
       CategoryCode: CategoryCode,
       SortCondition: 'ASC',
-      PageNo: 1,
+      PageNo: pageNo || 1,
     })
     // console.log(`✅ ${CategoryCode} 카테고리코드의 아이템 정보`)
 

--- a/Client/src/components/selector/OtherSelector.tsx
+++ b/Client/src/components/selector/OtherSelector.tsx
@@ -10,7 +10,7 @@ import { OtherInfo } from '../../types/Types'
 const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }) => {
   const darkMode = useThemeStore((state) => state.darkMode)
   const { toggleDrops, updateSelectionState, characterSelections } = useOtherSelectionStore()
-  const itemInfos = useMarketStore((state) => state.itemInfos)
+  const dropItemInfos = useMarketStore((state) => state.dropItemInfos)
 
   // 선택한 캐릭터가 선택가능한 other 컨텐츠 목록 불러오기
   const availableOther = getAvailableOthersByLevel(
@@ -95,7 +95,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
                 <div className='flex w-full'>
                   <h5 className='font-bold text-black'>1수 골드 :</h5>
                   <h5 className='ml-1 font-bold text-black'>
-                    {calculateGoldByDrops(defaultDrop, itemInfos)}G
+                    {calculateGoldByDrops(defaultDrop, dropItemInfos)}G
                   </h5>
                   <div className='ml-auto h-full'>
                     <Checkbox
@@ -127,7 +127,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
               <div className='mt-auto flex w-full justify-end'>
                 <h5 className='font-bold text-black'>종합 </h5>
                 <h5 className='ml-1 font-bold text-black'>
-                  {calculateGoldByDrops(dropByName, itemInfos).toLocaleString()}G
+                  {calculateGoldByDrops(dropByName, dropItemInfos).toLocaleString()}G
                 </h5>
               </div>
             </div>

--- a/Client/src/components/selector/OtherSelector.tsx
+++ b/Client/src/components/selector/OtherSelector.tsx
@@ -10,7 +10,7 @@ import { OtherInfo } from '../../types/Types'
 const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }) => {
   const darkMode = useThemeStore((state) => state.darkMode)
   const { toggleDrops, updateSelectionState, characterSelections } = useOtherSelectionStore()
-  const dropItemInfos = useMarketStore((state) => state.dropItemInfos)
+  const refineItemInfos = useMarketStore((state) => state.refineItemInfos)
 
   // 선택한 캐릭터가 선택가능한 other 컨텐츠 목록 불러오기
   const availableOther = getAvailableOthersByLevel(
@@ -95,7 +95,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
                 <div className='flex w-full'>
                   <h5 className='font-bold text-black'>1수 골드 :</h5>
                   <h5 className='ml-1 font-bold text-black'>
-                    {calculateGoldByDrops(defaultDrop, dropItemInfos)}G
+                    {calculateGoldByDrops(defaultDrop, refineItemInfos)}G
                   </h5>
                   <div className='ml-auto h-full'>
                     <Checkbox
@@ -127,7 +127,7 @@ const OtherSelector = ({ SelectedCharacterInfo }: { SelectedCharacterInfo: any }
               <div className='mt-auto flex w-full justify-end'>
                 <h5 className='font-bold text-black'>종합 </h5>
                 <h5 className='ml-1 font-bold text-black'>
-                  {calculateGoldByDrops(dropByName, dropItemInfos).toLocaleString()}G
+                  {calculateGoldByDrops(dropByName, refineItemInfos).toLocaleString()}G
                 </h5>
               </div>
             </div>

--- a/Client/src/constants/defaultItemList.ts
+++ b/Client/src/constants/defaultItemList.ts
@@ -1,21 +1,21 @@
 interface ItemInfo {
   name: string
-  code: number
+  CategoryCode: number
 }
 
 export const defaultItemList: ItemInfo[] = [
   // 무기 재료
-  { name: '운명의 파괴석', code: 50010 },
-  { name: '정제된 파괴강석', code: 50010 },
+  { name: '운명의 파괴석', CategoryCode: 50010 },
+  { name: '정제된 파괴강석', CategoryCode: 50010 },
 
   // 방어구 재료
-  { name: '운명의 수호석', code: 50010 },
-  { name: '정제된 수호강석', code: 50010 },
+  { name: '운명의 수호석', CategoryCode: 50010 },
+  { name: '정제된 수호강석', CategoryCode: 50010 },
 
   // 공통 재료
-  { name: '운명의 돌파석', code: 50010 },
-  { name: '찬란한 명예의 돌파석', code: 50010 },
+  { name: '운명의 돌파석', CategoryCode: 50010 },
+  { name: '찬란한 명예의 돌파석', CategoryCode: 50010 },
 
   // 보석은 Market이 아닌 Auction
-  { name: '1레벨 겁화의 보석', code: 210000 },
+  { name: '1레벨 겁화의 보석', CategoryCode: 210000 },
 ]

--- a/Client/src/hook/useExpeditionGoldData.ts
+++ b/Client/src/hook/useExpeditionGoldData.ts
@@ -10,7 +10,7 @@ export const useExpeditionGoldData = () => {
   const RaidSelections = useRaidSelectionStore((state) => state.characterSelections)
   const OtherSelection = useOtherSelectionStore((state) => state.characterSelections)
   const expeditions = useExpeditionStore((state) => state.expeditions)
-  const dropItemInfos = useMarketStore((state) => state.dropItemInfos)
+  const refineItemInfos = useMarketStore((state) => state.refineItemInfos)
 
   if (!expeditions) return []
 
@@ -20,7 +20,7 @@ export const useExpeditionGoldData = () => {
     raidGold: getRaidGoldForCharacter(character.name, RaidSelections),
     otherGold: calculateGoldByDrops(
       getOtherDropsForCharacter(character.name, OtherSelection),
-      dropItemInfos,
+      refineItemInfos,
     ),
   }))
 }

--- a/Client/src/hook/useExpeditionGoldData.ts
+++ b/Client/src/hook/useExpeditionGoldData.ts
@@ -10,7 +10,7 @@ export const useExpeditionGoldData = () => {
   const RaidSelections = useRaidSelectionStore((state) => state.characterSelections)
   const OtherSelection = useOtherSelectionStore((state) => state.characterSelections)
   const expeditions = useExpeditionStore((state) => state.expeditions)
-  const itemInfos = useMarketStore((state) => state.itemInfos)
+  const dropItemInfos = useMarketStore((state) => state.dropItemInfos)
 
   if (!expeditions) return []
 
@@ -20,7 +20,7 @@ export const useExpeditionGoldData = () => {
     raidGold: getRaidGoldForCharacter(character.name, RaidSelections),
     otherGold: calculateGoldByDrops(
       getOtherDropsForCharacter(character.name, OtherSelection),
-      itemInfos,
+      dropItemInfos,
     ),
   }))
 }

--- a/Client/src/hook/useLoaData.ts
+++ b/Client/src/hook/useLoaData.ts
@@ -20,7 +20,7 @@ const useLoaData = () => {
   )
 
   // 아이템 시세 정보 받아오기
-  const loadItemInfo = useMarketStore((state) => state.loadDropItemInfos)
+  const loadRefineItemInfo = useMarketStore((state) => state.loadRefineItemInfos)
 
   // 첫 로드 시 게스트 로그인 여부 확인
   // 게스트 로그인 정보가 있을시 localStorage 초기화
@@ -48,8 +48,8 @@ const useLoaData = () => {
   }, [selectedCharacter])
 
   useEffect(() => {
-    loadItemInfo()
-  }, [loadItemInfo])
+    loadRefineItemInfo()
+  }, [loadRefineItemInfo])
 }
 
 export default useLoaData

--- a/Client/src/hook/useLoaData.ts
+++ b/Client/src/hook/useLoaData.ts
@@ -20,7 +20,7 @@ const useLoaData = () => {
   )
 
   // 아이템 시세 정보 받아오기
-  const loadItemInfo = useMarketStore((state) => state.loadItemInfo)
+  const loadItemInfo = useMarketStore((state) => state.loadDropItemInfos)
 
   // 첫 로드 시 게스트 로그인 여부 확인
   // 게스트 로그인 정보가 있을시 localStorage 초기화

--- a/Client/src/main.tsx
+++ b/Client/src/main.tsx
@@ -1,10 +1,5 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './router/Router.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+createRoot(document.getElementById('root')!).render(<App />)

--- a/Client/src/stores/api/MarketStore.ts
+++ b/Client/src/stores/api/MarketStore.ts
@@ -17,17 +17,17 @@ interface ItemInfo {
 }
 
 interface MarketState {
-  dropItemInfos: Record<string, ItemInfo>
+  refineItemInfos: Record<string, ItemInfo>
   MarketLoading?: boolean
   MarketError?: string | null
-  loadDropItemInfos: () => Promise<void>
+  loadRefineItemInfos: () => Promise<void>
   resetState: () => void
 }
 
 export const useMarketStore = create<MarketState>((set) => ({
-  dropItemInfos: {},
+  refineItemInfos: {},
 
-  loadDropItemInfos: async () => {
+  loadRefineItemInfos: async () => {
     try {
       set({ MarketLoading: true, MarketError: null })
 
@@ -51,8 +51,8 @@ export const useMarketStore = create<MarketState>((set) => ({
               const jewelItem = res.Items[4] // 호출되는 10개 중 중간값
 
               set((state) => ({
-                dropItemInfos: {
-                  ...state.dropItemInfos,
+                refineItemInfos: {
+                  ...state.refineItemInfos,
                   [jewelItem.Name]: {
                     name: jewelItem.Name,
                     image: jewelItem.Icon,
@@ -92,7 +92,7 @@ export const useMarketStore = create<MarketState>((set) => ({
 
                 // 아이템 상태에 반영
                 set((state) => {
-                  const updated: Record<string, ItemInfo> = { ...state.dropItemInfos }
+                  const updated: Record<string, ItemInfo> = { ...state.refineItemInfos }
 
                   allItems.forEach((item: any) => {
                     updated[item.Name] = {
@@ -105,7 +105,7 @@ export const useMarketStore = create<MarketState>((set) => ({
                     }
                   })
 
-                  return { dropItemInfos: updated }
+                  return { refineItemInfos: updated }
                 })
               }
             }
@@ -119,11 +119,8 @@ export const useMarketStore = create<MarketState>((set) => ({
       set({ MarketError: error instanceof Error ? error.message : '아이템 정보 불러오기 실패' })
     } finally {
       set({ MarketLoading: false })
-      if (typeof window !== 'undefined') {
-        ;(window as any).marketStore = useMarketStore
-      }
     }
   },
 
-  resetState: () => set({ dropItemInfos: {} }),
+  resetState: () => set({ refineItemInfos: {} }),
 }))

--- a/Client/src/stores/api/MarketStore.ts
+++ b/Client/src/stores/api/MarketStore.ts
@@ -57,7 +57,7 @@ export const useMarketStore = create<MarketState>((set) => ({
               }))
             }
           } else {
-            res = await getItemData(apiKey, item.name, item.code)
+            res = await getItemData(apiKey, item.name, item.CategoryCode)
 
             if (res?.Items?.length > 0) {
               const itemData = res.Items[0]

--- a/Client/src/stores/api/MarketStore.ts
+++ b/Client/src/stores/api/MarketStore.ts
@@ -17,7 +17,7 @@ interface ItemInfo {
 }
 
 interface MarketState {
-  itemInfos: Record<string, ItemInfo>
+  dropItemInfos: Record<string, ItemInfo>
   MarketLoading?: boolean
   MarketError?: string | null
   loadItemInfo: () => Promise<void>
@@ -25,7 +25,7 @@ interface MarketState {
 }
 
 export const useMarketStore = create<MarketState>((set) => ({
-  itemInfos: {},
+  dropItemInfos: {},
 
   loadItemInfo: async () => {
     try {
@@ -43,8 +43,8 @@ export const useMarketStore = create<MarketState>((set) => ({
             if (res?.Items?.length > 0) {
               const jewelItem = res.Items[0]
               set((state) => ({
-                itemInfos: {
-                  ...state.itemInfos,
+                dropItemInfos: {
+                  ...state.dropItemInfos,
                   [jewelItem.Name]: {
                     name: jewelItem.Name,
                     image: jewelItem.Icon,
@@ -62,8 +62,8 @@ export const useMarketStore = create<MarketState>((set) => ({
             if (res?.Items?.length > 0) {
               const itemData = res.Items[0]
               set((state) => ({
-                itemInfos: {
-                  ...state.itemInfos,
+                dropItemInfos: {
+                  ...state.dropItemInfos,
                   [itemData.Name]: {
                     name: itemData.Name,
                     image: itemData.Icon,
@@ -85,8 +85,11 @@ export const useMarketStore = create<MarketState>((set) => ({
       set({ MarketError: error instanceof Error ? error.message : '아이템 정보 불러오기 실패' })
     } finally {
       set({ MarketLoading: false })
+      if (typeof window !== 'undefined') {
+        ;(window as any).marketStore = useMarketStore
+      }
     }
   },
 
-  resetState: () => set({ itemInfos: {} }),
+  resetState: () => set({ dropItemInfos: {} }),
 }))

--- a/Client/src/stores/api/MarketStore.ts
+++ b/Client/src/stores/api/MarketStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { getItemData, getJewelData } from '../../api/loaApi'
+import { getItemsByCategory, getJewelData } from '../../api/loaApi'
 import { getApiKey } from '../../api/userApi'
 import { defaultItemList } from '../../constants/defaultItemList'
 
@@ -20,28 +20,36 @@ interface MarketState {
   dropItemInfos: Record<string, ItemInfo>
   MarketLoading?: boolean
   MarketError?: string | null
-  loadItemInfo: () => Promise<void>
+  loadDropItemInfos: () => Promise<void>
   resetState: () => void
 }
 
 export const useMarketStore = create<MarketState>((set) => ({
   dropItemInfos: {},
 
-  loadItemInfo: async () => {
+  loadDropItemInfos: async () => {
     try {
       set({ MarketLoading: true, MarketError: null })
 
       const apiKey = getApiKey()
 
-      for (const item of defaultItemList) {
-        try {
-          let res
+      const categoryCodes = Array.from(new Set(defaultItemList.map((item) => item.CategoryCode)))
 
-          if (item.name === '1레벨 겁화의 보석') {
-            res = await getJewelData(apiKey, item.name)
+      const itemTier = [3, 4] // 3,4티어 재료 기준
+
+      for (const code of categoryCodes) {
+        try {
+          let res: any
+
+          // 보석 카테고리 코드
+          if (code === 210000) {
+            const itemName = defaultItemList.find((item) => item.CategoryCode === code)?.name ?? ''
+
+            res = await getJewelData(apiKey, itemName)
 
             if (res?.Items?.length > 0) {
-              const jewelItem = res.Items[0]
+              const jewelItem = res.Items[4] // 호출되는 10개 중 중간값
+
               set((state) => ({
                 dropItemInfos: {
                   ...state.dropItemInfos,
@@ -57,27 +65,53 @@ export const useMarketStore = create<MarketState>((set) => ({
               }))
             }
           } else {
-            res = await getItemData(apiKey, item.name, item.CategoryCode)
+            for (const tier of itemTier) {
+              const allItems: any[] = []
 
-            if (res?.Items?.length > 0) {
-              const itemData = res.Items[0]
-              set((state) => ({
-                dropItemInfos: {
-                  ...state.dropItemInfos,
-                  [itemData.Name]: {
-                    name: itemData.Name,
-                    image: itemData.Icon,
-                    BundleCount: itemData.BundleCount,
-                    YDayAvgPrice: itemData.YDayAvgPrice,
-                    RecentPrice: itemData.RecentPrice,
-                    CurrentMinPrice: itemData.CurrentMinPrice,
-                  },
-                },
-              }))
+              // 1페이지 먼저 호출
+              const firstPageRes = await getItemsByCategory(apiKey, code, tier, 1)
+              if (firstPageRes?.Items?.length > 0) {
+                allItems.push(...firstPageRes.Items)
+
+                const totalPages = Math.ceil(firstPageRes.TotalCount / firstPageRes.PageSize)
+
+                // 2페이지부터 끝까지 호출
+                for (let page = 2; page <= totalPages; page++) {
+                  try {
+                    const pageRes = await getItemsByCategory(apiKey, code, tier, page)
+                    if (pageRes?.Items?.length > 0) {
+                      allItems.push(...pageRes.Items)
+                    }
+                  } catch (pageErr) {
+                    console.warn(
+                      `⚠️ 코드 ${code}, 티어 ${tier}, 페이지 ${page} 에서 오류 발생`,
+                      pageErr,
+                    )
+                  }
+                }
+
+                // 아이템 상태에 반영
+                set((state) => {
+                  const updated: Record<string, ItemInfo> = { ...state.dropItemInfos }
+
+                  allItems.forEach((item: any) => {
+                    updated[item.Name] = {
+                      name: item.Name,
+                      image: item.Icon,
+                      BundleCount: item.BundleCount,
+                      YDayAvgPrice: item.YDayAvgPrice,
+                      RecentPrice: item.RecentPrice,
+                      CurrentMinPrice: item.CurrentMinPrice,
+                    }
+                  })
+
+                  return { dropItemInfos: updated }
+                })
+              }
             }
           }
         } catch (innerError) {
-          console.warn(`⚠️ ${item.name} 처리 중 오류 발생`, innerError)
+          console.warn(`⚠️ 카테고리 코드: ${code} 처리 중 오류 발생`, innerError)
           // 개별 아이템 오류는 무시하고 다음 아이템 진행
         }
       }

--- a/Client/src/utils/MarketDataUtils.ts
+++ b/Client/src/utils/MarketDataUtils.ts
@@ -1,10 +1,10 @@
 // 입력받은 Drop 내 아이템 명칭 및 갯수를 itemInfos의 아이템 시세에 맞춰 골드값을 계산하는 함수
 export const calculateGoldByDrops = (
   drops: { name: string; amount: number }[],
-  dropItemInfos: any,
+  refineItemInfos: any,
 ) => {
   let totalGold = drops.reduce((acc, drop) => {
-    const item = dropItemInfos[drop.name]
+    const item = refineItemInfos[drop.name]
     const price = item?.RecentPrice / item?.BundleCount || 0
     return acc + price * drop.amount
   }, 0)

--- a/Client/src/utils/MarketDataUtils.ts
+++ b/Client/src/utils/MarketDataUtils.ts
@@ -1,7 +1,10 @@
 // 입력받은 Drop 내 아이템 명칭 및 갯수를 itemInfos의 아이템 시세에 맞춰 골드값을 계산하는 함수
-export const calculateGoldByDrops = (drops: { name: string; amount: number }[], itemInfos: any) => {
+export const calculateGoldByDrops = (
+  drops: { name: string; amount: number }[],
+  dropItemInfos: any,
+) => {
   let totalGold = drops.reduce((acc, drop) => {
-    const item = itemInfos[drop.name]
+    const item = dropItemInfos[drop.name]
     const price = item?.RecentPrice / item?.BundleCount || 0
     return acc + price * drop.amount
   }, 0)


### PR DESCRIPTION
### ✨ 기능 추가
- `getItemsByCategory(categoryCode, pageNo, itemTier)` API 함수 구현
  - 카테고리 코드 기준으로 아이템 전체 조회
  - 페이지 번호 및 아이템 티어 매개변수 추가

### 🔄 리팩토링
- `defaultItemList` 항목의 `code` → `CategoryCode`로 키 명칭 변경
- `MarketStore` 내 `itemInfos` → `dropItemInfos`로 명확한 의미 전달을 위한 이름 변경
- `getItemData` → `getItemsByCategory` API 사용 방식으로 변경하여 재련 재료 조회 로직 개선
  - 티어별(3, 4)로 페이지를 순회하며 아이템 누적 처리
- 보석 조회 방식 name 기반 → `CategoryCode` 기반으로 통일
- 수집한 데이터를 `allItems` 배열에 저장한 후 `dropItemInfos` 상태에 일괄 반영
- 함수명 `loadDropItemInfos` → `loadRefineItemInfos`로 명확한 의미 전달을 위해 수정

### 🎨 프론트엔드 개발
- React StrictMode 제거 (API 호출 중복 최소화를 위함)

### 🧪 테스트 및 확인 내역
- 카테고리 코드 및 티어 기반으로 아이템 조회 기능 정상 동작 확인
- 티어별 재련 재료 아이템 및 보석 정보 정상 수집 및 상태 반영 확인
- 기존 API 대비 API 호출 수 감소 및 데이터 수집 안정성 확보