### PR TITLE
feat: 이메일 인증 기능 추가

### DIFF
--- a/Client/src/api/userApi.ts
+++ b/Client/src/api/userApi.ts
@@ -117,6 +117,33 @@ export const requestDeleteUser = async (email: string) => {
   }
 }
 
+export const sendEmailCode = async (email: string) => {
+  try {
+    const response = await axios.post('/api/users/email-verification', {
+      email: email,
+    })
+    console.log('✅ 코드 전송 성공:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('❌ 코드 전송 실패:', error)
+    throw error
+  }
+}
+
+export const checkEmailCode = async (email: string, code: string) => {
+  try {
+    const response = await axios.post('/api/users/email-verification/verify', {
+      email: email,
+      code: code,
+    })
+    console.log('✅ 코드 확인 성공:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('❌ 코드 확인 실패:', error)
+    throw error
+  }
+}
+
 export const storageClear = async () => {
   try {
     localStorage.removeItem('account-storage')

--- a/Client/src/api/userApi.ts
+++ b/Client/src/api/userApi.ts
@@ -117,10 +117,11 @@ export const requestDeleteUser = async (email: string) => {
   }
 }
 
-export const sendEmailCode = async (email: string) => {
+export const sendEmailCode = async (email: string, type: 'register' | 'password') => {
   try {
     const response = await axios.post('/api/users/email-verification', {
       email: email,
+      type: type,
     })
     console.log('✅ 코드 전송 성공:', response.data)
     return response.data

--- a/Client/src/components/Summary/SummaryPreview.tsx
+++ b/Client/src/components/Summary/SummaryPreview.tsx
@@ -16,7 +16,7 @@ const SummaryPreview = ({ viewport = '' }) => {
     return (
       <div className='flex h-full w-full flex-col items-center justify-center gap-4 opacity-80'>
         <h3 className='text-black'>주간 골드 설정을 해주세요</h3>
-        <Button text='설정하기' onClick={() => navigate('/Weekly-gold')} />
+        <Button text='설정하기' onClick={() => navigate('/Weekly-gold')} width={120} height={40} />
       </div>
     )
   }

--- a/Client/src/components/form/DeleteUserForm.tsx
+++ b/Client/src/components/form/DeleteUserForm.tsx
@@ -2,14 +2,19 @@ import { useNavigate } from 'react-router-dom'
 import { requestDeleteUser } from '../../api/userApi'
 import useAccountStore from '../../stores/others/AccountStore'
 import Button from '../ui/Button'
+import { useState } from 'react'
 
 const DeleteUserForm = () => {
   const navigate = useNavigate()
   const email = useAccountStore((state) => state.email)
 
+  const [isLoading, setIsLoading] = useState(false)
+
   const handleDeleteUser = async () => {
     const confirmDelete = window.confirm('정말로 탈퇴하시겠습니까?')
     if (!confirmDelete) return
+
+    setIsLoading(true)
 
     if (!email) {
       alert('이메일 정보가 없습니다. 다시 로그인해주세요.')
@@ -22,6 +27,7 @@ const DeleteUserForm = () => {
       console.error('회원 탈퇴 실패:', error)
       alert('회원 탈퇴 중 오류가 발생했습니다.')
     } finally {
+      setIsLoading(false)
       window.location.reload()
       alert('회원 탈퇴가 완료되었습니다.')
     }
@@ -35,6 +41,9 @@ const DeleteUserForm = () => {
         onClick={handleDeleteUser}
         lightColor='bg-red'
         darkColor='bg-black'
+        width={358}
+        height={40}
+        isLoading={isLoading}
       />
     </div>
   )

--- a/Client/src/components/form/FindPasswordForm.tsx
+++ b/Client/src/components/form/FindPasswordForm.tsx
@@ -119,11 +119,7 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
 
       {/* 최종 제출 버튼 */}
       <div className='mt-2 flex flex-col'>
-        <Button
-          type='submit'
-          text={isLoading ? '처리중...' : '비밀번호 변경'}
-          disabled={isLoading}
-        />
+        <Button type='submit' text='비밀번호 변경' isLoading={isLoading} width={358} height={40} />
       </div>
     </form>
   )

--- a/Client/src/components/form/FindPasswordForm.tsx
+++ b/Client/src/components/form/FindPasswordForm.tsx
@@ -1,44 +1,65 @@
 import { useForm, Controller } from 'react-hook-form'
+import { useState } from 'react'
 import Button from '../ui/Button'
 import Input from '../ui/Input'
 import ErrorText from '../ui/ErrorText'
-
+import { checkEmailCode, sendEmailCode } from '../../api/userApi'
+import { AxiosError } from 'axios'
 import { AuthFormData } from '../../types/Types'
 
-import { validateEmail, validatePassword, validateConfirmPassword } from '../../utils/validation'
+import {
+  validateEmail,
+  validatePassword,
+  validateConfirmPassword,
+  disabledEmailInput,
+  disableldVerificationCodeInput,
+} from '../../utils/validation'
 
-interface FindPasswordProps {
+interface RegisterFormProps {
   onSubmit: (data: AuthFormData) => void // 폼 제출 시 실행할 함수
   isLoading?: boolean // 로딩 상태
 }
 
-const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) => {
+const FindPasswordForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
+  // 이메일 인증여부 상태 관리
+  const [emailChecked, setEmailChecked] = useState(false)
+  const [verificationCode, setVerificationCode] = useState('')
+  const [verificationCodeChecked, setVerificationCodeChecked] = useState(false)
+
+  // 버튼 클릭시 각각의 로딩 상태 관리
+  const [loadingEmailSend, setLoadingEmailSend] = useState(false)
+  const [loadingVerificationCode, setLoadingVerificationCode] = useState(false)
+
   // useForm 훅으로 폼을 제어
   const {
     control,
     handleSubmit,
     watch,
-
+    setError,
+    clearErrors,
     formState: { errors }, // 에러 정보
   } = useForm<AuthFormData>({
     mode: 'onTouched', // onBlur 시 값 검사
     defaultValues: {
       email: '',
+      verificationCode: '',
       password: '',
       confirmPassword: '',
     },
   })
 
-  const { password } = watch() // 필요한 값 구조분해
+  const { email, password } = watch() // 필요한 값 구조분해
 
   // 실제 폼 제출 함수 (유효성 검사를 통과한 경우만 실행)
   const handleFormSubmit = (data: AuthFormData) => {
     // 모든 값이 유효하고, 인증도 완료된 경우에만 onSubmit 호출
     if (
       !errors.email &&
+      !errors.verificationCode &&
       !errors.password &&
       !errors.confirmPassword &&
       data.email &&
+      data.verificationCode &&
       data.password &&
       data.confirmPassword
     ) {
@@ -47,6 +68,7 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
       // 실패 시 로그 출력 및 알림
       console.log('유효성 검사 실패:', {
         emailError: errors.email?.message,
+        verificationCodeError: errors.verificationCode?.message,
         passwordError: errors.password?.message,
         confirmPasswordError: errors.confirmPassword?.message,
       })
@@ -54,28 +76,130 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
     }
   }
 
+  const handleError = (field: keyof AuthFormData, error: any) => {
+    if (error instanceof AxiosError) {
+      setError(field, {
+        message: error.response?.data.message || field + ' 에 대한 오류가 발생했습니다.',
+      })
+      alert(error.response?.data.message)
+    } else {
+      setError(field, { message: '알수 없는 오류가 발생했습니다.' })
+    }
+  }
+
   return (
-    <form className='flex flex-col' onSubmit={handleSubmit(handleFormSubmit)}>
+    <form className='flex w-[358px] flex-col' onSubmit={handleSubmit(handleFormSubmit)}>
       {/* 이메일 필드 */}
-      <Controller
-        name='email'
-        control={control}
-        rules={{
-          validate: (value) => validateEmail(value) || true, // 유효하지 않으면 에러 메시지, 유효하면 true
-        }}
-        render={({ field }) => (
-          <>
+      <div className={`flex w-full items-center justify-between`}>
+        <Controller
+          name='email'
+          control={control}
+          rules={{
+            validate: (value) => validateEmail(value) || true, // 유효하지 않으면 에러 메시지, 유효하면 true
+          }}
+          render={({ field }) => (
             <Input
               {...field}
               placeholder='이메일'
-              className={`w-full ${errors.email ? 'mb-1' : ''}`}
-              type='email'
               error={errors.email?.message || ''}
+              width={260}
+              disabled={disabledEmailInput(email, emailChecked, errors.email?.message || '')}
+              type='email'
+              onChange={(e) => {
+                field.onChange(e.target.value) // 입력값 변경
+                setEmailChecked(false) // 인증 초기화
+                clearErrors('email') // 에러 초기화
+              }}
             />
-            <ErrorText message={errors.email?.message} />
-          </>
-        )}
-      />
+          )}
+        />
+        <Button
+          text='발송'
+          type='button'
+          disabled={disabledEmailInput(email, emailChecked, errors.email?.message || '')}
+          isLoading={loadingEmailSend}
+          onClick={async () => {
+            setLoadingEmailSend(true)
+            try {
+              if (validateEmail(email)) {
+                return alert('이메일 형식이 올바르지 않습니다.')
+              }
+              const code = await sendEmailCode(email, 'password')
+
+              if (!code) {
+                setError('email', { message: code.message })
+              } else {
+                clearErrors('email')
+                alert('이메일 인증 코드를 전송했습니다.')
+                setEmailChecked(true) // 인증 상태 true
+              }
+            } catch (error) {
+              handleError('email', error)
+            } finally {
+              setLoadingEmailSend(false) // 로딩 종료
+            }
+          }}
+        />
+      </div>
+      <ErrorText message={errors.email?.message} />
+
+      {/* 이메일 인증 코드 필드 */}
+      <div className={`flex w-full items-center justify-between`}>
+        <Controller
+          name='verificationCode'
+          control={control}
+          render={({ field }) => (
+            <Input
+              {...field}
+              placeholder='이메일 인증코드'
+              error={errors.verificationCode?.message || ''}
+              width={260}
+              disabled={disableldVerificationCodeInput(
+                verificationCode,
+                verificationCodeChecked,
+                emailChecked,
+                errors.verificationCode?.message,
+              )}
+              type='verificationCode'
+              onChange={(e) => {
+                field.onChange(e.target.value) // 입력값 변경
+                setVerificationCode(e.target.value)
+                setVerificationCodeChecked(false) // 인증 초기화
+                clearErrors('verificationCode') // 에러 초기화
+              }}
+            />
+          )}
+        />
+        <Button
+          text='인증'
+          type='button'
+          disabled={disableldVerificationCodeInput(
+            verificationCode,
+            verificationCodeChecked,
+            emailChecked,
+            errors.verificationCode?.message || '',
+          )}
+          isLoading={loadingVerificationCode}
+          onClick={async () => {
+            setLoadingVerificationCode(true)
+            try {
+              const code = await checkEmailCode(email, verificationCode)
+              if (!code) {
+                setError('verificationCode', { message: code.message })
+              } else {
+                clearErrors('verificationCode')
+                alert('이메일 인증이 완료되었습니다.')
+                setVerificationCodeChecked(true) // 인증 상태 true
+              }
+            } catch (error) {
+              handleError('verificationCode', error)
+            } finally {
+              setLoadingVerificationCode(false)
+            }
+          }}
+        />
+      </div>
+      <ErrorText message={errors.verificationCode?.message} />
 
       {/* 비밀번호 필드 */}
       <Controller
@@ -86,12 +210,7 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
         }}
         render={({ field }) => (
           <>
-            <Input
-              {...field}
-              placeholder='비밀번호'
-              className={`w-full ${errors.password ? 'mb-1' : ''}`}
-              type='password'
-            />
+            <Input {...field} placeholder='신규 비밀번호' type='password' />
             <ErrorText message={errors.password?.message} />
           </>
         )}
@@ -106,12 +225,7 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
         }}
         render={({ field }) => (
           <>
-            <Input
-              {...field}
-              placeholder='비밀번호 재입력'
-              className={`w-full ${errors.confirmPassword ? 'mb-1' : ''}`}
-              type='password'
-            />
+            <Input {...field} placeholder='비밀번호 재입력' type='password' />
             <ErrorText message={errors.confirmPassword?.message} />
           </>
         )}
@@ -119,7 +233,13 @@ const FindPasswordForm = ({ onSubmit, isLoading = false }: FindPasswordProps) =>
 
       {/* 최종 제출 버튼 */}
       <div className='mt-2 flex flex-col'>
-        <Button type='submit' text='비밀번호 변경' isLoading={isLoading} width={358} height={40} />
+        <Button
+          type='submit'
+          text={isLoading ? '처리중...' : '회원가입'}
+          width={358}
+          height={40}
+          disabled={isLoading}
+        />
       </div>
     </form>
   )

--- a/Client/src/components/form/GusetLoginForm.tsx
+++ b/Client/src/components/form/GusetLoginForm.tsx
@@ -15,11 +15,13 @@ const GuestLoginForm = ({ onSubmit, isLoading = false }: GuestLoginFormProps) =>
       className='flex flex-col'
     >
       <Button
-        text={isLoading ? '로그인 중...' : '게스트 로그인'}
+        text='게스트 로그인'
         type='submit'
-        disabled={isLoading}
         darkColor='bg-black'
         lightColor='bg-red'
+        width={358}
+        height={40}
+        isLoading={isLoading}
       />
     </form>
   )

--- a/Client/src/components/form/LoginForm.tsx
+++ b/Client/src/components/form/LoginForm.tsx
@@ -86,7 +86,14 @@ const LoginForm = ({ onSubmit, isLoading = false }: LoginFormProps) => {
         </Link>
       </div>
       <div className='mt-2 flex flex-col'>
-        <Button text={isLoading ? '로그인 중...' : '로그인'} type='submit' disabled={isLoading} />
+        <Button
+          text='로그인'
+          type='submit'
+          disabled={isLoading}
+          isLoading={isLoading}
+          width={358}
+          height={40}
+        />
       </div>
     </form>
   )

--- a/Client/src/components/form/RegisterForm.tsx
+++ b/Client/src/components/form/RegisterForm.tsx
@@ -118,7 +118,7 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
           )}
         />
         <Button
-          text='인증'
+          text='발송'
           type='button'
           disabled={disabledEmailInput(email, emailChecked, errors.email?.message || '')}
           onClick={async () => {

--- a/Client/src/components/form/RegisterForm.tsx
+++ b/Client/src/components/form/RegisterForm.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react'
 import Button from '../ui/Button'
 import Input from '../ui/Input'
 import ErrorText from '../ui/ErrorText'
-
+import { checkEmailCode, sendEmailCode } from '../../api/userApi'
+import { AxiosError } from 'axios'
 import { AuthFormData } from '../../types/Types'
 
 import {
@@ -17,7 +18,6 @@ import {
   disabledEmailInput,
   disableldVerificationCodeInput,
 } from '../../utils/validation'
-import { checkEmailCode, sendEmailCode } from '../../api/userApi'
 
 interface RegisterFormProps {
   onSubmit: (data: AuthFormData) => void // 폼 제출 시 실행할 함수
@@ -25,15 +25,20 @@ interface RegisterFormProps {
 }
 
 const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
-  // API Key, 캐릭터 인증 여부 상태 관리
-
-  const [apiKeyChecked, setApiKeyChecked] = useState(false)
-  const [characterChecked, setCharacterChecked] = useState(false)
-
   // 이메일 인증여부 상태 관리
   const [emailChecked, setEmailChecked] = useState(false)
   const [verificationCode, setVerificationCode] = useState('')
   const [verificationCodeChecked, setVerificationCodeChecked] = useState(false)
+
+  // 버튼 클릭시 각각의 로딩 상태 관리
+  const [loadingEmailSend, setLoadingEmailSend] = useState(false)
+  const [loadingVerificationCode, setLoadingVerificationCode] = useState(false)
+  const [loadingApiKey, setLoadingApiKey] = useState(false)
+  const [loadingCharacter, setLoadingCharacter] = useState(false)
+
+  // API Key, 캐릭터 인증 여부 상태 관리
+  const [apiKeyChecked, setApiKeyChecked] = useState(false)
+  const [characterChecked, setCharacterChecked] = useState(false)
 
   // useForm 훅으로 폼을 제어
   const {
@@ -74,7 +79,8 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
       data.confirmPassword &&
       data.apiKey &&
       data.character &&
-      apiKeyChecked
+      apiKeyChecked &&
+      characterChecked
     ) {
       onSubmit(data)
     } else {
@@ -91,10 +97,21 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
     }
   }
 
+  const handleError = (field: keyof AuthFormData, error: any) => {
+    if (error instanceof AxiosError) {
+      setError(field, {
+        message: error.response?.data.message || field + ' 에 대한 오류가 발생했습니다.',
+      })
+      alert(error.response?.data.message)
+    } else {
+      setError(field, { message: '알수 없는 오류가 발생했습니다.' })
+    }
+  }
+
   return (
     <form className='flex w-[358px] flex-col' onSubmit={handleSubmit(handleFormSubmit)}>
       {/* 이메일 필드 */}
-      <div className={`${errors.email ? 'mb-1' : ''} flex w-full items-center justify-between`}>
+      <div className={`flex w-full items-center justify-between`}>
         <Controller
           name='email'
           control={control}
@@ -121,25 +138,34 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
           text='발송'
           type='button'
           disabled={disabledEmailInput(email, emailChecked, errors.email?.message || '')}
+          isLoading={loadingEmailSend}
           onClick={async () => {
-            const code = await sendEmailCode(email)
+            setLoadingEmailSend(true)
+            try {
+              if (validateEmail(email)) {
+                return alert('이메일 형식이 올바르지 않습니다.')
+              }
+              const code = await sendEmailCode(email)
 
-            if (!code) {
-              setError('email', { message: code.message })
-            } else {
-              clearErrors('email')
-              alert('이메일 인증 코드를 전송했습니다.')
+              if (!code) {
+                setError('email', { message: code.message })
+              } else {
+                clearErrors('email')
+                alert('이메일 인증 코드를 전송했습니다.')
+                setEmailChecked(true) // 인증 상태 true
+              }
+            } catch (error) {
+              handleError('email', error)
+            } finally {
+              setLoadingEmailSend(false) // 로딩 종료
             }
-            setEmailChecked(true) // 인증 상태 true
           }}
         />
       </div>
       <ErrorText message={errors.email?.message} />
 
       {/* 이메일 인증 코드 필드 */}
-      <div
-        className={`${errors.verificationCode ? 'mb-1' : ''} flex w-full items-center justify-between`}
-      >
+      <div className={`flex w-full items-center justify-between`}>
         <Controller
           name='verificationCode'
           control={control}
@@ -152,8 +178,8 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
               disabled={disableldVerificationCodeInput(
                 verificationCode,
                 verificationCodeChecked,
-                errors.verificationCode?.message || '',
                 emailChecked,
+                errors.verificationCode?.message,
               )}
               type='verificationCode'
               onChange={(e) => {
@@ -171,18 +197,26 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
           disabled={disableldVerificationCodeInput(
             verificationCode,
             verificationCodeChecked,
-            errors.verificationCode?.message || '',
             emailChecked,
+            errors.verificationCode?.message || '',
           )}
+          isLoading={loadingVerificationCode}
           onClick={async () => {
-            const code = await checkEmailCode(email, verificationCode)
-            if (!code) {
-              setError('verificationCode', { message: code.message })
-            } else {
-              clearErrors('verificationCode')
-              alert('이메일 인증가 완료되었습니다.')
+            setLoadingVerificationCode(true)
+            try {
+              const code = await checkEmailCode(email, verificationCode)
+              if (!code) {
+                setError('verificationCode', { message: code.message })
+              } else {
+                clearErrors('verificationCode')
+                alert('이메일 인증이 완료되었습니다.')
+                setVerificationCodeChecked(true) // 인증 상태 true
+              }
+            } catch (error) {
+              handleError('verificationCode', error)
+            } finally {
+              setLoadingVerificationCode(false)
             }
-            setVerificationCodeChecked(true) // 인증 상태 true
           }}
         />
       </div>
@@ -219,7 +253,7 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
       />
 
       {/* API Key 필드와 인증 버튼 */}
-      <div className={`${errors.apiKey ? 'mb-1' : ''} flex w-full items-center justify-between`}>
+      <div className={`flex w-full items-center justify-between`}>
         <Controller
           name='apiKey'
           control={control}
@@ -244,21 +278,29 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
           text='인증'
           type='button'
           disabled={disabledApiKeyInput(apiKey, apiKeyChecked, errors.apiKey?.message || '')}
+          isLoading={loadingApiKey}
           onClick={async () => {
-            const error = await validateApiKey(apiKey) // API 키 유효성 검사
-            if (error) {
-              setError('apiKey', { message: error })
-            } else {
-              clearErrors('apiKey')
+            setLoadingApiKey(true)
+            try {
+              const error = await validateApiKey(apiKey) // API 키 유효성 검사
+              if (error) {
+                setError('apiKey', { message: error })
+              } else {
+                setApiKeyChecked(true)
+                clearErrors('apiKey')
+              }
+            } catch (error) {
+              handleError('apiKey', error)
+            } finally {
+              setLoadingApiKey(false)
             }
-            setApiKeyChecked(true) // 인증 상태 true
           }}
         />
       </div>
       <ErrorText message={errors.apiKey?.message} />
 
       {/* 캐릭터명 필드와 인증 버튼 */}
-      <div className={`${errors.character ? 'mb-1' : ''} flex w-full items-center justify-between`}>
+      <div className={`flex w-full items-center justify-between`}>
         <Controller
           name='character'
           control={control}
@@ -296,14 +338,22 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
             apiKeyChecked,
             errors.apiKey?.message || '',
           )}
+          isLoading={loadingCharacter}
           onClick={async () => {
-            const error = await validateCharacterName(character, apiKey)
-            if (error) {
-              setError('character', { message: error })
-            } else {
-              clearErrors('character')
+            setLoadingCharacter(true)
+            try {
+              const error = await validateCharacterName(character, apiKey)
+              if (error) {
+                setError('character', { message: error })
+              } else {
+                setCharacterChecked(true)
+                clearErrors('character')
+              }
+            } catch (error) {
+              handleError('character', error)
+            } finally {
+              setLoadingCharacter(false)
             }
-            setCharacterChecked(true)
           }}
         />
       </div>
@@ -311,7 +361,13 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
 
       {/* 최종 제출 버튼 */}
       <div className='mt-2 flex flex-col'>
-        <Button type='submit' text={isLoading ? '처리중...' : '회원가입'} disabled={isLoading} />
+        <Button
+          type='submit'
+          text={isLoading ? '처리중...' : '회원가입'}
+          width={358}
+          height={40}
+          disabled={isLoading}
+        />
       </div>
     </form>
   )

--- a/Client/src/components/form/RegisterForm.tsx
+++ b/Client/src/components/form/RegisterForm.tsx
@@ -145,7 +145,7 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
               if (validateEmail(email)) {
                 return alert('이메일 형식이 올바르지 않습니다.')
               }
-              const code = await sendEmailCode(email)
+              const code = await sendEmailCode(email, 'register')
 
               if (!code) {
                 setError('email', { message: code.message })

--- a/Client/src/components/form/RegisterForm.tsx
+++ b/Client/src/components/form/RegisterForm.tsx
@@ -153,6 +153,7 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
                 verificationCode,
                 verificationCodeChecked,
                 errors.verificationCode?.message || '',
+                emailChecked,
               )}
               type='verificationCode'
               onChange={(e) => {
@@ -171,6 +172,7 @@ const RegisterForm = ({ onSubmit, isLoading = false }: RegisterFormProps) => {
             verificationCode,
             verificationCodeChecked,
             errors.verificationCode?.message || '',
+            emailChecked,
           )}
           onClick={async () => {
             const code = await checkEmailCode(email, verificationCode)

--- a/Client/src/components/form/UserinfoForm.tsx
+++ b/Client/src/components/form/UserinfoForm.tsx
@@ -10,6 +10,7 @@ import {
   disabledCharacterInput,
   disabledApiKeyInput,
 } from '../../utils/validation'
+import useAccountStore from '../../stores/others/AccountStore'
 
 interface UserinfoFormProps {
   onSubmit: (data: AuthFormData) => void // 폼 제출 시 실행할 함수
@@ -20,6 +21,8 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
   // API Key, 캐릭터 인증 여부를 상태로 관리
   const [apiKeyChecked, setApiKeyChecked] = useState(false)
   const [characterChecked, setCharacterChecked] = useState(false)
+
+  const email = useAccountStore((state) => state.email)
 
   // useForm 훅으로 폼을 제어
   const {
@@ -35,6 +38,7 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
     defaultValues: {
       apiKey: '',
       character: '',
+      email: email,
     },
   })
 
@@ -145,7 +149,7 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
 
       <div className='mt-2 flex flex-col'>
         {/* 변경 사항 저장 */}
-        <Button type='submit' text={isLoading ? '처리중...' : '변경 적용'} disabled={isLoading} />
+        <Button type='submit' text='변경 사항 저장' isLoading={isLoading} width={358} height={40} />
       </div>
     </form>
   )

--- a/Client/src/components/form/UserinfoForm.tsx
+++ b/Client/src/components/form/UserinfoForm.tsx
@@ -130,7 +130,6 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
             apiKeyChecked,
             errors.apiKey?.message || '',
           )}
-          className='h-full'
           onClick={async () => {
             const error = await validateCharacterName(character, apiKey)
             if (error) {

--- a/Client/src/components/form/UserinfoForm.tsx
+++ b/Client/src/components/form/UserinfoForm.tsx
@@ -91,7 +91,7 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
           render={({ field }) => (
             <Input
               {...field}
-              placeholder='API KEY'
+              placeholder='새로 입력할 API KEY'
               error={errors.apiKey?.message || ''}
               width={260}
               disabled={disabledApiKeyInput(apiKey, apiKeyChecked, errors.apiKey?.message || '')}
@@ -138,7 +138,7 @@ const UserinfoForm = ({ onSubmit, isLoading = false }: UserinfoFormProps) => {
           render={({ field }) => (
             <Input
               {...field}
-              placeholder='대표 캐릭터명'
+              placeholder='새로 입력할 대표 캐릭터명'
               width={260}
               disabled={disabledCharacterInput(
                 character,

--- a/Client/src/components/ui/Button.tsx
+++ b/Client/src/components/ui/Button.tsx
@@ -6,7 +6,6 @@ interface ButtonProps {
   textStyle?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   type?: 'button' | 'submit' | 'reset'
-  className?: string
   mode?: boolean
   darkColor?: string
   lightColor?: string
@@ -15,7 +14,7 @@ interface ButtonProps {
   height?: number
 }
 
-const Button: React.FC<ButtonProps> = ({
+const Button = ({
   text = '',
   onClick,
   textStyle = '',
@@ -24,23 +23,23 @@ const Button: React.FC<ButtonProps> = ({
   darkColor = 'bg-black',
   lightColor = 'bg-green',
   disabled = false,
-  width = '80px',
-  height = '40',
-}) => {
+  width = 80,
+  height = 40,
+}: ButtonProps) => {
   const { darkMode } = useThemeStore()
 
   return (
     <button
       type={type}
       onClick={onClick}
-      className={` ${mode ? (darkMode ? `${darkColor}` : `${lightColor}`) : ''} flex shrink-0 items-center justify-center rounded-lg ${disabled ? 'cursor-not-allowed opacity-70' : ''}`}
+      className={` ${mode ? (darkMode ? `${darkColor}` : `${lightColor}`) : ''} flex items-center justify-center rounded-lg ${disabled ? 'cursor-not-allowed opacity-70' : ''}`}
       style={{ width: `${width}px`, height: `${height}px` }}
       disabled={disabled}
     >
       {textStyle ? (
         <div className={textStyle}>{text}</div>
       ) : (
-        <div className='text-lg font-extrabold'>{text}</div>
+        <div className='flex shrink-0 text-lg font-extrabold'>{text}</div>
       )}
     </button>
   )

--- a/Client/src/components/ui/Button.tsx
+++ b/Client/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import useThemeStore from '../../stores/others/ThemeStore'
+import Loading from '../ui/Loading'
 
 interface ButtonProps {
   text?: string | number
@@ -12,6 +13,7 @@ interface ButtonProps {
   disabled?: boolean
   width?: number
   height?: number
+  isLoading?: boolean
 }
 
 const Button = ({
@@ -25,8 +27,19 @@ const Button = ({
   disabled = false,
   width = 80,
   height = 40,
+  isLoading = false,
 }: ButtonProps) => {
   const { darkMode } = useThemeStore()
+
+  if (isLoading)
+    return (
+      <div
+        className='flex items-center justify-center rounded-lg'
+        style={{ width: `${width}px`, height: `${height}px` }}
+      >
+        <Loading />
+      </div>
+    )
 
   return (
     <button

--- a/Client/src/components/ui/Loading.tsx
+++ b/Client/src/components/ui/Loading.tsx
@@ -1,6 +1,14 @@
-const Loading = () => {
+interface LoadingProps {
+  width?: number
+  height?: number
+}
+
+const Loading = ({ width = 40, height = 40 }: LoadingProps) => {
   return (
-    <div className='border-t-green h-20 w-20 animate-spin rounded-full border-8 border-gray-300' />
+    <div
+      style={{ width: `${width}px`, height: `${height}px` }}
+      className='border-t-green animate-spin rounded-full border-8 border-gray-300'
+    />
   )
 }
 

--- a/Client/src/hook/useAuthRedirect.ts
+++ b/Client/src/hook/useAuthRedirect.ts
@@ -10,39 +10,48 @@ export const getAuthStatus = () => {
 }
 
 // 로그인 or 게스트 유저만 접근 가능 (비 로그인 x)
-export const useRequireUserOrGuest = (redirectUrl: string = '/') => {
+export const useRequireUserOrGuest = (redirectUrl: string = '/', message?: boolean) => {
   const navigate = useNavigate()
 
   useEffect(() => {
     const { isGuest, isLogin } = getAuthStatus()
 
     if (!isLogin && !isGuest) {
+      if (message) {
+        alert('로그인 해주세요!!')
+      }
       navigate(redirectUrl)
     }
   }, [navigate, redirectUrl])
 }
 
 // 로그인 유저만 접근 가능 (게스트, 비 로그인 x)
-export const useRequireUser = (redirectUrl: string = '/') => {
+export const useRequireUser = (redirectUrl: string = '/', message?: boolean) => {
   const navigate = useNavigate()
 
   useEffect(() => {
     const { isGuest, isLogin } = getAuthStatus()
 
     if (isGuest || !isLogin) {
+      if (message) {
+        alert('로그인 해주세요!!')
+      }
       navigate(redirectUrl)
     }
   }, [navigate, redirectUrl])
 }
 
 // 비 로그인 유저만 접근 가능 (로그인, 게스트 x)
-export const useRequireNoAuth = (redirectUrl: string = '/') => {
+export const useRequireNoAuth = (redirectUrl: string = '/', message?: boolean) => {
   const navigate = useNavigate()
 
   useEffect(() => {
     const { isGuest, isLogin } = getAuthStatus()
 
     if (isLogin || isGuest) {
+      if (message) {
+        alert('로그아웃 됩니다!!')
+      }
       navigate(redirectUrl)
     }
   }, [navigate, redirectUrl])

--- a/Client/src/pages/FindPassword.tsx
+++ b/Client/src/pages/FindPassword.tsx
@@ -32,7 +32,7 @@ const FindPassword = () => {
     <div className='min-h-screen bg-gray-600 pt-[50px]'>
       <main className='w-full space-y-[10px] p-[10px]'>
         <div className='flex w-full justify-center gap-x-[10px]'>
-          <Block width={390} height={340}>
+          <Block width={390} height={398}>
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h2 className='mx-auto leading-none font-extrabold text-black'>비밀번호 변경</h2>
               <FindPasswordForm onSubmit={handlePasswordSubmit} isLoading={isLoading} />

--- a/Client/src/pages/Login.tsx
+++ b/Client/src/pages/Login.tsx
@@ -9,7 +9,8 @@ import GuestLoginForm from '../components/form/GusetLoginForm'
 import { useNavigate } from 'react-router-dom'
 
 const Login = () => {
-  const [isLoading, setIsLoading] = useState(false)
+  const [loadingGuest, setLoadingGuest] = useState(false)
+  const [loadingAuth, setLoadingAuth] = useState(false)
 
   const setApiKey = useAccountStore((state) => state.setApiKey)
   const setCharacter = useAccountStore((state) => state.setCharacter)
@@ -21,7 +22,7 @@ const Login = () => {
   useRequireNoAuth()
 
   const handleLoginSubmit = async (data: AuthFormData) => {
-    setIsLoading(true)
+    setLoadingAuth(true)
     try {
       const respone = await requestLoginUser(data)
 
@@ -33,21 +34,21 @@ const Login = () => {
     } catch (error: any) {
       alert(error.response?.data?.message || '로그인 중 오류 발생')
     } finally {
-      setIsLoading(false)
+      setLoadingAuth(false)
     }
   }
 
   const handleGusetLogin = async () => {
-    setIsLoading(true)
+    setLoadingGuest(true)
     try {
       await requestGuestUser()
     } catch (error: any) {
       alert(error.response?.data?.message || '게스트 로그인 중 오류 발생')
     } finally {
-      window.location.href = '/'
-
+      setLoadingGuest(false)
       alert('게스트 로그인 성공')
-      setIsLoading(false)
+
+      window.location.href = '/'
     }
   }
 
@@ -59,8 +60,8 @@ const Login = () => {
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h2 className='mx-auto leading-none font-extrabold text-black'>로그인</h2>
               <div className='flex flex-col gap-2'>
-                <LoginForm onSubmit={handleLoginSubmit} isLoading={isLoading} />
-                <GuestLoginForm onSubmit={handleGusetLogin} isLoading={isLoading} />
+                <LoginForm onSubmit={handleLoginSubmit} isLoading={loadingAuth} />
+                <GuestLoginForm onSubmit={handleGusetLogin} isLoading={loadingGuest} />
               </div>
             </div>
           </Block>

--- a/Client/src/pages/Register.tsx
+++ b/Client/src/pages/Register.tsx
@@ -41,7 +41,7 @@ const Register = () => {
     <div className='min-h-screen bg-gray-600 pt-[50px]'>
       <main className='space-y-[10px] p-[10px]'>
         <div className='flex justify-center gap-x-[10px]'>
-          <Block width={390} height={466}>
+          <Block width={390} height={534}>
             <div className='flex h-full w-full flex-col gap-5 p-4'>
               <h2 className='mx-auto leading-none font-extrabold text-black'>회원가입</h2>
               <RegisterForm onSubmit={handleRegisterSubmit} isLoading={isLoading} />

--- a/Client/src/pages/Userinfo.tsx
+++ b/Client/src/pages/Userinfo.tsx
@@ -31,6 +31,7 @@ const Userinfo = () => {
 
       await requestProfileUpdate(data)
 
+      alert('변경이 완료되었습니다.')
       navigate('/')
     } catch (error: any) {
       // 실패 시 이전 값으로 복원

--- a/Client/src/types/Types.ts
+++ b/Client/src/types/Types.ts
@@ -1,5 +1,6 @@
 export interface AuthFormData {
   email: string
+  verificationCode: string
   password: string
   confirmPassword: string
   apiKey: string

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -108,9 +108,6 @@ export const disableldVerificationCodeInput = (
   verificationCodeChecked: boolean,
   verificationCodeError: string,
 ) => {
-  console.log('verificationCodeError', verificationCodeError)
-  console.log('verificationCodeChecked', verificationCodeChecked)
-  console.log('verificationCode', verificationCode)
   if (verificationCodeError) {
     return false
   }

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -107,9 +107,13 @@ export const disableldVerificationCodeInput = (
   verificationCode: string,
   verificationCodeChecked: boolean,
   verificationCodeError: string,
+  emailChecked: boolean,
 ) => {
   if (verificationCodeError) {
     return false
+  }
+  if (emailChecked == false) {
+    return true
   }
   if (verificationCodeChecked && verificationCode) {
     return true

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -92,6 +92,35 @@ export const disabledApiKeyInput = (
   }
 }
 
+export const disabledEmailInput = (email: string, emailChecked: boolean, emailError: string) => {
+  if (emailError) {
+    return false
+  }
+  if (emailChecked && email) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export const disableldVerificationCodeInput = (
+  verificationCode: string,
+  verificationCodeChecked: boolean,
+  verificationCodeError: string,
+) => {
+  console.log('verificationCodeError', verificationCodeError)
+  console.log('verificationCodeChecked', verificationCodeChecked)
+  console.log('verificationCode', verificationCode)
+  if (verificationCodeError) {
+    return false
+  }
+  if (verificationCodeChecked && verificationCode) {
+    return true
+  } else {
+    return false
+  }
+}
+
 export const disabledCharacterInput = (
   character: string,
   characterChecked: boolean,

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -39,7 +39,10 @@ export const validateApiKey = async (apiKey: string) => {
     if (res.status === 200) alert('API 키 검증 성공.')
     return ''
   } catch (e: any) {
-    if (e.response && e.response.status === 401) {
+    if (
+      (e.response && e.response.status === 401) ||
+      (e.message && e.message.includes('String contains non ISO-8859-1 code point'))
+    ) {
       return 'API 키가 유효하지 않습니다.'
     }
     return 'API 키 검증 중 오류가 발생했습니다.'
@@ -78,29 +81,12 @@ export const validateCharacterName = async (character: string, apiKey: string) =
   }
 }
 
-export const disabledApiKeyInput = (
-  apiKey: string,
-  apiKeyChecked: boolean,
-  apikeyError: string,
-) => {
-  if (apikeyError) return false
-
-  if (apiKeyChecked && apiKey) {
-    return true
-  } else {
-    return false
-  }
-}
-
 export const disabledEmailInput = (email: string, emailChecked: boolean, emailError?: string) => {
-  if (emailError) {
-    return true
-  }
-  if (emailChecked && email) {
-    return true
-  } else {
-    return false
-  }
+  if (emailError) return false
+
+  if (emailChecked && email) return true
+
+  return false
 }
 
 export const disableldVerificationCodeInput = (
@@ -109,17 +95,25 @@ export const disableldVerificationCodeInput = (
   emailChecked: boolean,
   verificationCodeError?: string,
 ) => {
-  if (verificationCodeError) {
-    return true
-  }
-  if (emailChecked == false) {
-    return true
-  }
-  if (verificationCodeChecked && verificationCode) {
-    return true
-  } else {
-    return false
-  }
+  if (verificationCodeError) return false
+
+  if (!emailChecked) return true
+
+  if (verificationCodeChecked && emailChecked && verificationCode) return true
+
+  return false
+}
+
+export const disabledApiKeyInput = (
+  apiKey: string,
+  apiKeyChecked: boolean,
+  apikeyError: string,
+) => {
+  if (apikeyError) return false
+
+  if (apiKeyChecked && apiKey) return true
+
+  return false
 }
 
 export const disabledCharacterInput = (
@@ -130,15 +124,13 @@ export const disabledCharacterInput = (
   apiKeyChecked: boolean,
   apiKeyError: string,
 ) => {
-  if (!disabledApiKeyInput(apiKey, apiKeyChecked, apiKeyError)) {
-    return true
-  }
-  if (characterError) {
-    return false
-  }
-  if (characterChecked && character) {
-    return true
-  } else {
-    return false
-  }
+  const apikeyState = disabledApiKeyInput(apiKey, apiKeyChecked, apiKeyError)
+
+  if (characterError) return false
+
+  if (!apikeyState) return true
+
+  if (character && characterChecked && apikeyState) return true
+
+  return false
 }

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -13,7 +13,6 @@ export const validatePassword = (value: string) => {
 }
 
 export const validateConfirmPassword = (password: string, confirmPassword: string) => {
-  if (!confirmPassword) return '비밀번호를 재입력하세요.'
   if (password !== confirmPassword) return '비밀번호가 일치하지 않습니다.'
   return ''
 }

--- a/Client/src/utils/validation.ts
+++ b/Client/src/utils/validation.ts
@@ -92,9 +92,9 @@ export const disabledApiKeyInput = (
   }
 }
 
-export const disabledEmailInput = (email: string, emailChecked: boolean, emailError: string) => {
+export const disabledEmailInput = (email: string, emailChecked: boolean, emailError?: string) => {
   if (emailError) {
-    return false
+    return true
   }
   if (emailChecked && email) {
     return true
@@ -106,11 +106,11 @@ export const disabledEmailInput = (email: string, emailChecked: boolean, emailEr
 export const disableldVerificationCodeInput = (
   verificationCode: string,
   verificationCodeChecked: boolean,
-  verificationCodeError: string,
   emailChecked: boolean,
+  verificationCodeError?: string,
 ) => {
   if (verificationCodeError) {
-    return false
+    return true
   }
   if (emailChecked == false) {
     return true

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -17,6 +17,7 @@
         "jsonwebtoken": "^9.0.2",
         "mariadb": "^3.4.2",
         "mysql2": "^3.14.1",
+        "nodemailer": "^7.0.5",
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
@@ -2533,6 +2534,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "mariadb": "^3.4.2",
     "mysql2": "^3.14.1",
+    "nodemailer": "^7.0.5",
     "sequelize": "^6.37.7"
   },
   "devDependencies": {

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -18,6 +18,7 @@ usersRouter.use('/userinfo', require('./routes/userinfo'))
 usersRouter.use('/find-password', require('./routes/find-password'))
 usersRouter.use('/weekly-gold', require('./routes/weekly-gold'))
 usersRouter.use('/delete', require('./routes/delete-user'))
+usersRouter.use('/email-verification', require('./routes/email-Verification'))
 app.use('/api/users', usersRouter)
 
 // 정적 파일

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -18,7 +18,7 @@ usersRouter.use('/userinfo', require('./routes/userinfo'))
 usersRouter.use('/find-password', require('./routes/find-password'))
 usersRouter.use('/weekly-gold', require('./routes/weekly-gold'))
 usersRouter.use('/delete', require('./routes/delete-user'))
-usersRouter.use('/email-verification', require('./routes/email-Verification'))
+usersRouter.use('/email-verification', require('./routes/email-verification'))
 app.use('/api/users', usersRouter)
 
 // 정적 파일

--- a/Server/src/config/smtpConfig.js
+++ b/Server/src/config/smtpConfig.js
@@ -1,0 +1,16 @@
+const nodemailer = require('nodemailer')
+
+const transporter = nodemailer.createTransport({
+  service: 'Gmail',
+  auth: {
+    user: process.env.NODEMAILER_EMAIL,
+    pass: process.env.NODEMAILER_PASSWORD,
+  },
+  tls: {
+    rejectUnauthorized: false,
+  },
+})
+
+module.exports = {
+  transporter,
+}

--- a/Server/src/routes/email-verification.js
+++ b/Server/src/routes/email-verification.js
@@ -1,0 +1,36 @@
+const express = require('express')
+const router = express.Router()
+
+const { sendVerificationEmail, verificationCode } = require('../utils/mail-service')
+
+// 이메일 인증코드 발송
+router.post('/', async (req, res) => {
+  const { email } = req.body
+  if (!email) return res.status(400).json({ error: '이메일이 필요합니다.' })
+
+  try {
+    await sendVerificationEmail(email)
+    res.status(201).json({ message: '인증 코드가 이메일로 발송되었습니다.' })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: '이메일 발송 실패' })
+  }
+})
+
+// 이메일 인증
+router.post('/verify', (req, res) => {
+  const { email, code } = req.body
+  if (!email || !code) return res.status(400).json({ error: '이메일과 코드가 필요합니다.' })
+
+  const savedCode = verificationCode[email]
+  if (!savedCode) return res.status(404).json({ error: '인증 코드가 존재하지 않습니다.' })
+
+  if (savedCode === code) {
+    delete verificationCode[email]
+    return res.json({ message: '이메일 인증이 완료되었습니다.' })
+  } else {
+    return res.status(400).json({ error: '인증 코드가 올바르지 않습니다.' })
+  }
+})
+
+module.exports = router

--- a/Server/src/routes/email-verification.js
+++ b/Server/src/routes/email-verification.js
@@ -6,21 +6,26 @@ const { sendVerificationEmail, verificationCode } = require('../utils/mail-servi
 
 // 이메일 인증코드 발송
 router.post('/', async (req, res) => {
-  const { email } = req.body
+  const { email, type } = req.body
+
+  if (!email) return res.status(400).json({ message: '이메일을 입력하세요.' })
+
   const existingUser = await User.findOne({ where: { email } })
 
-  if (!email) return res.status(400).json({ message: '이메일를 입력하세요' })
+  if (type === 'register' && existingUser) {
+    return res.status(400).json({ message: '이미 등록된 이메일입니다.' })
+  }
 
-  if (existingUser) {
-    return res.status(400).json({ message: '이미 등록된 이메일 입니다.' })
+  if (type === 'password' && !existingUser) {
+    return res.status(400).json({ message: '등록되지 않은 이메일입니다.' })
   }
 
   try {
     await sendVerificationEmail(email)
-    res.status(201).json({ message: '인증 코드가 이메일로 발송되었습니다.' })
+    return res.status(201).json({ message: '인증 코드가 이메일로 발송되었습니다.' })
   } catch (error) {
     console.error(error)
-    res.status(500).json({ error: '이메일 발송 실패' })
+    return res.status(500).json({ message: '이메일 발송 실패' })
   }
 })
 

--- a/Server/src/routes/email-verification.js
+++ b/Server/src/routes/email-verification.js
@@ -1,12 +1,19 @@
 const express = require('express')
 const router = express.Router()
+const { User } = require('../models')
 
 const { sendVerificationEmail, verificationCode } = require('../utils/mail-service')
 
 // 이메일 인증코드 발송
 router.post('/', async (req, res) => {
   const { email } = req.body
-  if (!email) return res.status(400).json({ error: '이메일이 필요합니다.' })
+  const existingUser = await User.findOne({ where: { email } })
+
+  if (!email) return res.status(400).json({ message: '이메일를 입력하세요' })
+
+  if (existingUser) {
+    return res.status(400).json({ message: '이미 등록된 이메일 입니다.' })
+  }
 
   try {
     await sendVerificationEmail(email)
@@ -20,16 +27,16 @@ router.post('/', async (req, res) => {
 // 이메일 인증
 router.post('/verify', (req, res) => {
   const { email, code } = req.body
-  if (!email || !code) return res.status(400).json({ error: '이메일과 코드가 필요합니다.' })
+  if (!email || !code) return res.status(400).json({ message: '이메일과 코드가 필요합니다.' })
 
   const savedCode = verificationCode[email]
-  if (!savedCode) return res.status(404).json({ error: '인증 코드가 존재하지 않습니다.' })
+  if (!savedCode) return res.status(404).json({ message: '인증 코드가 존재하지 않습니다.' })
 
   if (savedCode === code) {
     delete verificationCode[email]
     return res.json({ message: '이메일 인증이 완료되었습니다.' })
   } else {
-    return res.status(400).json({ error: '인증 코드가 올바르지 않습니다.' })
+    return res.status(400).json({ message: '인증 코드가 올바르지 않습니다.' })
   }
 })
 

--- a/Server/src/utils/mail-service.js
+++ b/Server/src/utils/mail-service.js
@@ -1,0 +1,23 @@
+const { transporter } = require('../config/smtpConfig')
+
+const verificationCode = {}
+
+const sendVerificationEmail = async (toEmail) => {
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase() // 6자리 코드
+
+  verificationCode[toEmail] = code
+
+  const mailOptions = {
+    from: process.env.NODEMAILER_EMAIL,
+    to: toEmail,
+    subject: 'LOAPLAN 이메일 인증 요청',
+    html: `
+      <h1>이메일 인증 안내</h1>
+      <p>이메일 인증코드 : <strong>${code}</strong></p>
+    `,
+  }
+
+  await transporter.sendMail(mailOptions)
+}
+
+module.exports = { sendVerificationEmail, verificationCode }


### PR DESCRIPTION
## ✨ 기능 추가  
- 이메일 인증 코드 6자리 난수 생성 및 서버 메모리 저장 구현  
- Nodemailer를 활용한 Gmail SMTP 메일 발송 기능 추가  
- 이메일 인증 코드 발송 및 검증 API 구현 (/email-verification, /email-verification/verify)  
- 인증 성공 시 서버 메모리 내 인증코드 삭제  
- 이메일 중복 체크 로직 분기 처리 (회원가입 및 비밀번호 구분)
- 인증 커스텀 훅에 사용자 알림 메시지 기능 추가  

---

## 🎨 프론트엔드 개발  
- 이메일 인증 입력 필드 및 UI 컴포넌트 추가  
- UserinfoForm, 회원가입, 비밀번호 찾기 폼에 이메일 인증 기능 통합  
- API 키 및 캐릭터 인증 버튼별 로딩 상태 및 비활성화 조건 개선  
- AxiosError 공통 처리 함수(handleError) 도입  
- 버튼 컴포넌트에 로딩 애니메이션 및 크기 조정 적용  
- 인증 입력 필드 placeholder에 "새로 입력할" 문구 추가  
- 게스트 로그인과 일반 로그인 로딩 상태 분리  

---

## 🔄 리팩토링  
- 인증 관련 disabledInput 함수 조건문 단순화  
- 중복 코드 제거 및 코드 가독성 향상  
- 개발용 콘솔 로그 삭제  

---

## 🧪 테스트 및 확인 내역  
- 이메일 인증 코드 발송 및 검증 정상 작동 확인  
- API 키, 캐릭터 인증 로딩 상태 정상 처리 확인  
- 인증 실패 및 성공 시 사용자 알림 메시지 정상 출력 확인  
- 게스트/일반 로그인 로딩 상태 분리 정상 작동 확인  
- 백엔드 API 정상 응답 및 인증 코드 메모리 관리 정상 작동 확인  
- 프론트엔드 인증 UI/UX 전반 정상 동작 확인  
