### PR TITLE
feat: 게스트 API 사용시 에러 방지 기능 추가

### DIFF
--- a/Client/src/api/instance.ts
+++ b/Client/src/api/instance.ts
@@ -1,7 +1,19 @@
-import axios from 'axios'
+import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import { guestAccount } from '../constants/guestStorage'
 
-export const createLostarkInstance = (apikey: string) => {
-  const apiKey = 'bearer ' + apikey
+const guestApiKeys = [
+  guestAccount.apiKey,
+  guestAccount.apikey_2,
+  guestAccount.apiKey_3,
+  guestAccount.apiKey_4,
+].filter(Boolean) // VITE 환경변수가 없을 경우(undefined)를 대비해 배열에서 제거
+
+export const createLostarkInstance = (apikey: string): AxiosInstance => {
+  // 게스트 인스턴스 유무 파악
+  const isGuestMode = guestApiKeys.includes(apikey)
+
+  // 기본 API-Key 인덱스
+  let currentKeyIndex = 0
 
   const instance = axios.create({
     baseURL: 'https://developer-lostark.game.onstove.com',
@@ -11,16 +23,51 @@ export const createLostarkInstance = (apikey: string) => {
     },
   })
 
+  // 요청 인터셉터: 요청 헤더 설정에만 집중합니다.
   instance.interceptors.request.use(
-    function (config: any) {
-      // console.log('✅ Lostark API 응답')
-      config.headers!.authorization = apiKey
+    (config: InternalAxiosRequestConfig) => {
+      let currentApiKey = apikey
+
+      if (isGuestMode) {
+        currentApiKey = guestApiKeys[currentKeyIndex]
+      }
+
+      config.headers.authorization = `bearer ${currentApiKey}`
       return config
     },
-    function (error) {
-      console.error('❌ Lostark API 요청 오류:', error)
+    (error: AxiosError) => {
+      // 어차피 response 인터셉터에서 모든 에러를 처리할 것이므로,
+      // 여기서 로깅하면 중복이 발생합니다.
       return Promise.reject(error)
     },
   )
+
+  // 응답 인터셉터: 모든 응답 처리(성공, 재시도, 최종 실패 로깅)를 전담합니다.
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const originalRequest = error.config as InternalAxiosRequestConfig
+
+      if (
+        error.response?.status === 429 &&
+        isGuestMode &&
+        currentKeyIndex < guestApiKeys.length - 1
+      ) {
+        currentKeyIndex++
+
+        // 헤더를 직접 수정하는 대신, instance.defaults를 사용하는 것도 좋은 방법이지만
+        // 현재 구조에서는 originalRequest를 수정하는 것이 직관적입니다.
+        const newApiKey = guestApiKeys[currentKeyIndex]
+        originalRequest.headers.authorization = `bearer ${newApiKey}`
+
+        return instance(originalRequest)
+      }
+
+      // ✅ 최종 실패 지점: 재시도 조건이 맞지 않거나 모든 재시도에 실패하면 이 곳으로 옵니다.
+      console.error('❌ Lostark API 최종 오류:', error.response?.data || error.message)
+      return Promise.reject(error)
+    },
+  )
+
   return instance
 }

--- a/Client/src/constants/guestStorage.ts
+++ b/Client/src/constants/guestStorage.ts
@@ -1,9 +1,14 @@
 import type { RaidSelection, OtherSelection } from '../types/Types' // 타입 정의 경로 맞게 수정
 
+// 게스트 정보
+// apikey 값이 4개인 이유: To many request 오류 대비
 export const guestAccount = {
   email: 'guest@guest.com',
   character: '이크리처',
-  apiKey: import.meta.env.VITE_GUEST_API_KEY,
+  apiKey: import.meta.env.VITE_GUEST_API_KEY, // LOAPLAN2 API-Key
+  apikey_2: import.meta.env.VITE_GUEST_API_KEY_2, // LOAPLAN3 API-Key
+  apiKey_3: import.meta.env.VITE_GUEST_API_KEY_3, // LOAPLAN4 API-Key
+  apiKey_4: import.meta.env.VITE_GUEST_API_KEY_4, // LOAPLAN5 API-Key
 }
 
 export const guestRaidSelection = {


### PR DESCRIPTION
## ✨ 기능 추가

- Axios 인터셉터를 활용해  게스트 API 호출 시, 'Too Many Requests 에러시 예비 API 키 교체하여 요청을 재시도
  - `response` 인터셉터를 사용해 429 에러 감지
  - 모든 예비 키 소진 시 최종적으로 에러 반환
  - 일반 사용자의 API 호출에는 영향을 주지 않음