### PR TITLE
fix: 버튼의 텍스트 색상오류 수정

### DIFF
--- a/Client/src/components/ui/Button.tsx
+++ b/Client/src/components/ui/Button.tsx
@@ -52,7 +52,7 @@ const Button = ({
       {textStyle ? (
         <div className={textStyle}>{text}</div>
       ) : (
-        <div className='flex shrink-0 text-lg font-extrabold'>{text}</div>
+        <div className='flex shrink-0 text-lg font-extrabold text-white'>{text}</div>
       )}
     </button>
   )


### PR DESCRIPTION
## 🧪 버그 수정
- 버튼의 텍스트 색상 오류 수정 (모바일 디바이스 확인 필요)